### PR TITLE
fix: resolve DataTable search not working in production

### DIFF
--- a/app/components/dataTable/DataTable.tsx
+++ b/app/components/dataTable/DataTable.tsx
@@ -10,7 +10,7 @@ import {
   useReactTable,
   type VisibilityState,
 } from '@tanstack/react-table'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import {
   Table,
   TableBody,
@@ -44,8 +44,17 @@ export function DataTable<TData, TValue>({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const [globalFilter, setGlobalFilter] = useState('')
+  const [isMounted, setIsMounted] = useState(false)
 
-  const table = useReactTable({
+  // Track client-side mount to prevent SSR hydration mismatch
+  // TanStack Table's getFilteredRowModel() relies on client-side JS functions
+  // that don't serialize properly during SSR
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  // Only apply filtering after client-side hydration is complete
+  const tableConfig = useMemo(() => ({
     columns: columns,
     data: data,
     getCoreRowModel: getCoreRowModel(),
@@ -61,9 +70,12 @@ export function DataTable<TData, TValue>({
       sorting,
       columnVisibility,
       rowSelection,
-      globalFilter,
+      // Only apply globalFilter after mount to prevent hydration mismatch
+      globalFilter: isMounted ? globalFilter : '',
     },
-  })
+  }), [columns, data, sorting, columnVisibility, rowSelection, globalFilter, enableRowSelection, isMounted])
+
+  const table = useReactTable(tableConfig)
 
   useEffect(() => {
     if (onRowSelectionChange) {


### PR DESCRIPTION
1. The change is in app/components/dataTable/DataTable.tsx
  2. The fix adds client-side mount tracking to prevent SSR hydration mismatch with TanStack Table's
  filtering
  3. The project uses conventional commit style with prefixes like feat:, fix:

  This is a bug fix for the search functionality not working in production due to SSR hydration issues.
  The commit message should follow the fix: prefix pattern.

 The commit fixes the SSR hydration mismatch that was causing search to not work in production by adding
  an isMounted state to only apply the global filter after client-side hydration is complete.

