### PR TITLE
Release: 03-06-2026 - POS, Company, and Organization Structure (#129)

### DIFF
--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -113,11 +113,18 @@ export const navigationItems = [
         path: '/invitations',
         icon: Mail,
       },
+      {
+        name: 'Modules',
+        nameKey: 'sidebar.items.modules' as TranslationKey,
+        path: '/settings/modules',
+        icon: Settings,
+      },
     ],
   },
   {
     section: 'Inventory',
     sectionKey: 'sidebar.sections.inventory' as TranslationKey,
+    moduleKey: 'inventory',
     icon: Package,
     color: 'accent-inventory', // amber for inventory domain
     items: [
@@ -182,6 +189,7 @@ export const navigationItems = [
   {
     section: 'Accounting',
     sectionKey: 'sidebar.sections.accounting' as TranslationKey,
+    moduleKey: 'accounting',
     icon: Building2,
     color: 'accent-accounting', // emerald for accounting domain
     items: [
@@ -226,6 +234,7 @@ export const navigationItems = [
   {
     section: 'POS',
     sectionKey: 'sidebar.sections.pos' as TranslationKey,
+    moduleKey: 'pos',
     icon: ShoppingCart,
     color: 'accent-pos',
     items: [
@@ -258,6 +267,7 @@ export const navigationItems = [
   {
     section: 'Appointments',
     sectionKey: 'sidebar.sections.appointments' as TranslationKey,
+    moduleKey: 'appointments',
     icon: CalendarDays,
     color: 'accent-appointments', // blue for appointments domain
     items: [

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import type {
   OrganizationMember,
 } from "~/server/auth/organization.server";
 import type { SessionData } from "~/server/auth/session.server";
+import type { ModuleKey } from "~/features/modules/constants";
 
 interface AuthContextType {
   session: SessionData;
@@ -21,6 +22,7 @@ interface AuthContextType {
     slug: string;
     isAdmin?: boolean;
   }>;
+  moduleAccess: ModuleKey[];
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);

--- a/app/features/home/components/Modules.tsx
+++ b/app/features/home/components/Modules.tsx
@@ -1,53 +1,48 @@
-import { BarChart3, FileText, Package, Receipt } from 'lucide-react'
 import { Link } from 'react-router'
 import { Card, CardContent } from '~/components/ui/card'
-
-const modules = [
-  {
-    icon: Package,
-    title: 'Inventory',
-    description: 'Manage products and stock efficiently.',
-    href: '/inventory',
-  },
-  {
-    icon: Receipt,
-    title: 'Invoicing',
-    description: 'Create and manage invoices for your clients.',
-    href: '/invoices',
-  },
-  {
-    icon: BarChart3,
-    title: 'Accounting',
-    description: 'Record accounting entries and general balances.',
-    href: '/journal-entries',
-  },
-  {
-    icon: FileText,
-    title: 'Accounts Payable',
-    description: 'Manage pending payments to your suppliers.',
-    href: '/purchase/orders',
-  },
-]
+import { useAuth } from '~/contexts/AuthContext'
+import { APP_MODULES, MODULE_META } from '~/features/modules/constants'
 
 export default function Modules() {
+  const { moduleAccess, permissions } = useAuth()
+
+  // Super admin sees all modules; regular users see only accessible ones
+  const visibleModules = permissions.isSuperAdmin
+    ? APP_MODULES
+    : APP_MODULES.filter((key) => moduleAccess.includes(key))
+
+  if (visibleModules.length === 0) {
+    return (
+      <div>
+        <h3 className='mb-4 text-lg font-semibold'>
+          What would you like to do today?
+        </h3>
+        <p className='text-muted-foreground text-sm'>
+          No tenés módulos habilitados. Contactá al administrador.
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div>
       <h3 className='mb-4 text-lg font-semibold'>
         What would you like to do today?
       </h3>
       <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
-        {modules.map((mod) => {
-          const Icon = mod.icon
+        {visibleModules.map((key) => {
+          const meta = MODULE_META[key]
+          const Icon = meta.icon
           return (
-            <Link key={mod.title} to={mod.href}>
+            <Link key={key} to={meta.route}>
               <Card className='hover:bg-accent/50 h-full transition-colors'>
                 <CardContent className='p-6'>
                   <div className='bg-primary/10 mb-4 flex h-10 w-10 items-center justify-center rounded-lg'>
                     <Icon className='text-primary h-5 w-5' />
                   </div>
-                  <h4 className='font-semibold'>{mod.title}</h4>
+                  <h4 className='font-semibold'>{meta.label}</h4>
                   <p className='text-muted-foreground mt-1 text-sm'>
-                    {mod.description}
+                    {meta.description}
                   </p>
                 </CardContent>
               </Card>

--- a/app/features/modules/constants.ts
+++ b/app/features/modules/constants.ts
@@ -1,0 +1,51 @@
+import {
+  Calculator,
+  Calendar,
+  Package,
+  ShoppingCart,
+} from 'lucide-react'
+
+export const APP_MODULES = [
+  'pos',
+  'inventory',
+  'accounting',
+  'appointments',
+] as const
+
+export type ModuleKey = (typeof APP_MODULES)[number]
+export type ModuleAccessLevel = 'none' | 'user' | 'admin'
+
+export const MODULE_META: Record<
+  ModuleKey,
+  {
+    label: string
+    icon: typeof ShoppingCart
+    description: string
+    route: string
+  }
+> = {
+  pos: {
+    label: 'Punto de Venta',
+    icon: ShoppingCart,
+    description: 'Terminal y gestión de caja',
+    route: '/pos',
+  },
+  inventory: {
+    label: 'Inventario',
+    icon: Package,
+    description: 'Productos, stock y sucursales',
+    route: '/products',
+  },
+  accounting: {
+    label: 'Contabilidad',
+    icon: Calculator,
+    description: 'Facturas, journal entries, cuentas',
+    route: '/invoices',
+  },
+  appointments: {
+    label: 'Citas',
+    icon: Calendar,
+    description: 'Calendario y servicios',
+    route: '/appointments',
+  },
+}

--- a/app/features/modules/schemas.ts
+++ b/app/features/modules/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import { APP_MODULES } from './constants'
+
+export const moduleKeySchema = z.enum(APP_MODULES)
+export const moduleAccessLevelSchema = z.enum(['none', 'user', 'admin'])
+
+export const toggleOrgModuleSchema = z.object({
+  organizationId: z.string().uuid(),
+  moduleKey: moduleKeySchema,
+  isActive: z
+    .string()
+    .transform((v) => v === 'true')
+    .or(z.boolean()),
+})
+
+export const setMemberModuleAccessSchema = z.object({
+  memberId: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  access: z.record(moduleKeySchema, moduleAccessLevelSchema),
+})
+
+export type ToggleOrgModuleInput = z.infer<typeof toggleOrgModuleSchema>
+export type SetMemberModuleAccessInput = z.infer<
+  typeof setMemberModuleAccessSchema
+>

--- a/app/features/modules/server/repository.ts
+++ b/app/features/modules/server/repository.ts
@@ -1,0 +1,165 @@
+import { and, eq } from 'drizzle-orm'
+import { db } from '~/server/db'
+import {
+  memberModuleAccessModel,
+  organizationModuleModel,
+} from '~/server/db/schemas/modules'
+import { APP_MODULES, type ModuleAccessLevel, type ModuleKey } from '../constants'
+
+class ModulesRepository {
+  async getOrgModules(organizationId: string) {
+    return db
+      .select()
+      .from(organizationModuleModel)
+      .where(eq(organizationModuleModel.organizationId, organizationId))
+  }
+
+  async getActiveModulesForOrg(organizationId: string): Promise<ModuleKey[]> {
+    const rows = await db
+      .select({ moduleKey: organizationModuleModel.moduleKey })
+      .from(organizationModuleModel)
+      .where(
+        and(
+          eq(organizationModuleModel.organizationId, organizationId),
+          eq(organizationModuleModel.isActive, true)
+        )
+      )
+    return rows.map((r) => r.moduleKey as ModuleKey)
+  }
+
+  async setOrgModuleActive(
+    organizationId: string,
+    moduleKey: ModuleKey,
+    isActive: boolean
+  ) {
+    const existing = await db
+      .select({ id: organizationModuleModel.id })
+      .from(organizationModuleModel)
+      .where(
+        and(
+          eq(organizationModuleModel.organizationId, organizationId),
+          eq(organizationModuleModel.moduleKey, moduleKey)
+        )
+      )
+      .limit(1)
+
+    if (existing.length > 0) {
+      await db
+        .update(organizationModuleModel)
+        .set({ isActive, activatedAt: isActive ? new Date() : undefined })
+        .where(
+          and(
+            eq(organizationModuleModel.organizationId, organizationId),
+            eq(organizationModuleModel.moduleKey, moduleKey)
+          )
+        )
+    } else {
+      await db.insert(organizationModuleModel).values({
+        organizationId,
+        moduleKey,
+        isActive,
+      })
+    }
+  }
+
+  async getMemberModuleAccess(memberId: string, organizationId: string) {
+    return db
+      .select()
+      .from(memberModuleAccessModel)
+      .where(
+        and(
+          eq(memberModuleAccessModel.memberId, memberId),
+          eq(memberModuleAccessModel.organizationId, organizationId)
+        )
+      )
+  }
+
+  async getAccessibleModulesForMember(
+    memberId: string,
+    organizationId: string
+  ): Promise<ModuleKey[]> {
+    const rows = await db
+      .select({
+        moduleKey: memberModuleAccessModel.moduleKey,
+        accessLevel: memberModuleAccessModel.accessLevel,
+      })
+      .from(memberModuleAccessModel)
+      .where(
+        and(
+          eq(memberModuleAccessModel.memberId, memberId),
+          eq(memberModuleAccessModel.organizationId, organizationId)
+        )
+      )
+
+    return rows
+      .filter((r) => r.accessLevel !== 'none')
+      .map((r) => r.moduleKey as ModuleKey)
+  }
+
+  async setMemberModuleAccess(
+    memberId: string,
+    organizationId: string,
+    moduleKey: ModuleKey,
+    accessLevel: ModuleAccessLevel
+  ) {
+    const existing = await db
+      .select({ id: memberModuleAccessModel.id })
+      .from(memberModuleAccessModel)
+      .where(
+        and(
+          eq(memberModuleAccessModel.memberId, memberId),
+          eq(memberModuleAccessModel.moduleKey, moduleKey)
+        )
+      )
+      .limit(1)
+
+    if (existing.length > 0) {
+      await db
+        .update(memberModuleAccessModel)
+        .set({ accessLevel })
+        .where(
+          and(
+            eq(memberModuleAccessModel.memberId, memberId),
+            eq(memberModuleAccessModel.moduleKey, moduleKey)
+          )
+        )
+    } else {
+      await db.insert(memberModuleAccessModel).values({
+        memberId,
+        organizationId,
+        moduleKey,
+        accessLevel,
+      })
+    }
+  }
+
+  async setAllMemberModuleAccess(
+    memberId: string,
+    organizationId: string,
+    access: Partial<Record<ModuleKey, ModuleAccessLevel>>
+  ) {
+    for (const moduleKey of APP_MODULES) {
+      const level = access[moduleKey] ?? 'none'
+      await this.setMemberModuleAccess(memberId, organizationId, moduleKey, level)
+    }
+  }
+
+  async getMemberAccessLevel(
+    memberId: string,
+    moduleKey: ModuleKey
+  ): Promise<ModuleAccessLevel> {
+    const [row] = await db
+      .select({ accessLevel: memberModuleAccessModel.accessLevel })
+      .from(memberModuleAccessModel)
+      .where(
+        and(
+          eq(memberModuleAccessModel.memberId, memberId),
+          eq(memberModuleAccessModel.moduleKey, moduleKey)
+        )
+      )
+      .limit(1)
+    return (row?.accessLevel ?? 'none') as ModuleAccessLevel
+  }
+}
+
+export const modulesRepository = new ModulesRepository()

--- a/app/features/organization/schemas.ts
+++ b/app/features/organization/schemas.ts
@@ -3,18 +3,22 @@ import {
   createSelectSchema,
   createUpdateSchema,
 } from 'drizzle-zod'
-import type z from 'zod'
+import { z } from 'zod'
 import { organizationModel } from '~/server/db/schemas/auth'
 
-export const organizationCreateSchema = createInsertSchema(
-  organizationModel
-).omit({
+export const organizationCreateSchema = createInsertSchema(organizationModel, {
+  domain: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, 'Only lowercase letters, numbers and hyphens')
+    .optional(),
+  logo: z.string().optional(),
+}).omit({
   id: true,
 })
 
 export const selectOrganizationSchema = createSelectSchema(
   organizationModel
-).omit({ updatedAt: true, metadata: true })
+).omit({ updatedAt: true, metadata: true, domain: true })
 
 export const organizationUpdateSchema = createUpdateSchema(organizationModel)
 

--- a/app/features/organization/server/actions/create.action.test.ts
+++ b/app/features/organization/server/actions/create.action.test.ts
@@ -44,6 +44,7 @@ describe('createOrganization action', () => {
       updatedAt: new Date(),
       logo: null,
       metadata: null,
+      domain: null,
       isAdmin: false,
     })
 

--- a/app/features/organization/server/actions/create.action.ts
+++ b/app/features/organization/server/actions/create.action.ts
@@ -3,9 +3,19 @@ import { organizationCreateSchema } from '../../schemas'
 import { organizationRepository } from '../repository'
 
 export async function createOrganization(request: Request, input: FormData) {
-  const inputValues = Object.fromEntries(input)
-  const { data, error, success } =
-    organizationCreateSchema.safeParse(inputValues)
+  const logoFile = input.get('logo') as File | null
+  let logoBase64: string | undefined
+  if (logoFile && logoFile.size > 0) {
+    const buffer = await logoFile.arrayBuffer()
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    logoBase64 = `data:${logoFile.type};base64,${base64}`
+  }
+
+  const rawValues = Object.fromEntries(input)
+  const { data, error, success } = organizationCreateSchema.safeParse({
+    ...rawValues,
+    logo: logoBase64,
+  })
 
   if (!success) {
     return {
@@ -26,14 +36,20 @@ export async function createOrganization(request: Request, input: FormData) {
 
   const createdOrganization = await auth.api.createOrganization({
     body: {
-      name: data.name, //required
-      slug: data.slug, // required
-      logo: data.logo || '',
+      name: data.name,
+      slug: data.slug,
+      logo: logoBase64 || '',
       metadata: {},
       keepCurrentActiveOrganization: false,
     },
     headers: request.headers,
   })
+
+  if (data.domain && createdOrganization?.id) {
+    await organizationRepository.updateById(createdOrganization.id, {
+      domain: data.domain,
+    })
+  }
 
   return {
     success: true,

--- a/app/features/organization/server/actions/delete.action.ts
+++ b/app/features/organization/server/actions/delete.action.ts
@@ -1,25 +1,83 @@
+import { count, eq } from 'drizzle-orm'
 import auth from '~/server/auth-server'
 import { requireAuth } from '~/server/auth/session.server'
+import { db } from '~/server/db'
+import { companyModel } from '~/server/db/schemas/company'
+import { posTerminalModel } from '~/server/db/schemas/pos'
+import { memberModel } from '~/server/db/schemas/auth'
+import { modulesRepository } from '~/features/modules/server/repository'
 import { organizationRepository } from '../repository'
 import { getLocaleFromRequest, translateServer } from '~/i18n/translate.server'
 
 export async function deleteOrganization(request: Request, slug: string) {
-  // Authenticate user
-  await requireAuth(request)
+  const session = await requireAuth(request)
   const locale = getLocaleFromRequest(request)
 
-  const existingOrganzation = await organizationRepository.getBySlug(slug)
+  if (!session.user.isSuperAdmin) {
+    return { success: false, message: 'Forbidden' }
+  }
 
-  if (!existingOrganzation) {
+  const org = await organizationRepository.getBySlug(slug)
+  if (!org) {
     return {
       success: false,
       message: translateServer(locale, 'common.noOrganization'),
     }
   }
 
+  // Validation 1: active modules
+  const activeModules = await modulesRepository.getActiveModulesForOrg(org.id)
+  if (activeModules.length > 0) {
+    return {
+      success: false,
+      message: `Cannot delete: organization has ${activeModules.length} active module(s): ${activeModules.join(', ')}. Deactivate them first.`,
+    }
+  }
+
+  // Validation 2: members (more than just the owner)
+  const [memberCount] = await db
+    .select({ count: count() })
+    .from(memberModel)
+    .where(eq(memberModel.organizationId, org.id))
+
+  if ((memberCount?.count ?? 0) > 1) {
+    return {
+      success: false,
+      message: `Cannot delete: organization has ${memberCount.count} member(s). Remove all members first.`,
+    }
+  }
+
+  // Validation 3: companies linked to this org
+  const [companyCount] = await db
+    .select({ count: count() })
+    .from(companyModel)
+    .where(eq(companyModel.organizationId, org.id))
+
+  if ((companyCount?.count ?? 0) > 0) {
+    return {
+      success: false,
+      message: `Cannot delete: organization has ${companyCount.count} company(ies) linked. Remove them first.`,
+    }
+  }
+
+  // Validation 4: POS terminals
+  const [terminalCount] = await db
+    .select({ count: count() })
+    .from(posTerminalModel)
+    .where(eq(posTerminalModel.organizationId, org.id))
+
+  if ((terminalCount?.count ?? 0) > 0) {
+    return {
+      success: false,
+      message: `Cannot delete: organization has ${terminalCount.count} POS terminal(s). Remove them first.`,
+    }
+  }
+
+  // TODO: Validation 5: billing balance check (not implemented yet)
+
   try {
     const data = await auth.api.deleteOrganization({
-      body: { organizationId: existingOrganzation.id },
+      body: { organizationId: org.id },
       headers: request.headers,
     })
 

--- a/app/features/organization/server/actions/update.action.ts
+++ b/app/features/organization/server/actions/update.action.ts
@@ -1,0 +1,46 @@
+import { organizationUpdateSchema } from '../../schemas'
+import { organizationRepository } from '../repository'
+
+export async function updateOrganization(slug: string, input: FormData) {
+  const logoFile = input.get('logo') as File | null
+  let logoBase64: string | undefined
+
+  if (logoFile && logoFile.size > 0) {
+    const buffer = await logoFile.arrayBuffer()
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    logoBase64 = `data:${logoFile.type};base64,${base64}`
+  }
+
+  const rawValues = Object.fromEntries(input)
+  const { data, error, success } = organizationUpdateSchema.safeParse({
+    name: rawValues.name || undefined,
+    slug: rawValues.slug || undefined,
+    domain: rawValues.domain || undefined,
+    logo: logoBase64 ?? (rawValues.currentLogo as string) ?? undefined,
+  })
+
+  if (!success) {
+    return {
+      success: false,
+      message: 'Validation error',
+      errors: error.flatten().fieldErrors,
+    }
+  }
+
+  const org = await organizationRepository.getBySlug(slug)
+  if (!org) {
+    return { success: false, message: 'Organization not found' }
+  }
+
+  // If slug changed, verify it's not taken
+  if (data.slug && data.slug !== slug) {
+    const existing = await organizationRepository.getBySlug(data.slug)
+    if (existing) {
+      return { success: false, message: 'That slug is already taken by another organization.' }
+    }
+  }
+
+  const updated = await organizationRepository.updateById(org.id, data)
+
+  return { success: true, newSlug: updated?.slug ?? slug }
+}

--- a/app/features/organization/server/repository.ts
+++ b/app/features/organization/server/repository.ts
@@ -27,6 +27,15 @@ class OrganizationRepository {
     return data[0];
   }
 
+  async updateById(id: string, data: Partial<typeof organizationModel.$inferInsert>) {
+    const [org] = await db
+      .update(organizationModel)
+      .set(data)
+      .where(eq(organizationModel.id, id))
+      .returning()
+    return org
+  }
+
   async delete(id: string) {
     try {
       await db.delete(organizationModel).where(eq(organizationModel.id, id));

--- a/app/features/pos/components/PosCart.tsx
+++ b/app/features/pos/components/PosCart.tsx
@@ -4,13 +4,20 @@ import { Separator } from '~/components/ui/separator'
 import { useTranslation } from '~/i18n/context'
 import type { CartItem, CartTotals } from '../types'
 import { PosCartItem } from './PosCartItem'
+import { PosNumpad } from './PosNumpad'
 
 interface PosCartProps {
   items: CartItem[]
   totals: CartTotals
-  onQuantityChange: (productId: string, quantity: number) => void
-  onRemoveItem: (productId: string) => void
+  onQuantityChange: (cartItemId: string, quantity: number) => void
+  onRemoveItem: (cartItemId: string) => void
   onCheckout: () => void
+  selectedItemId: string | null
+  onItemSelect: (cartItemId: string) => void
+  numpadInput: string
+  onNumpadDigit: (d: string) => void
+  onNumpadBackspace: () => void
+  onNumpadClear: () => void
 }
 
 export function PosCart({
@@ -19,8 +26,17 @@ export function PosCart({
   onQuantityChange,
   onRemoveItem,
   onCheckout,
+  selectedItemId,
+  onItemSelect,
+  numpadInput,
+  onNumpadDigit,
+  onNumpadBackspace,
+  onNumpadClear,
 }: PosCartProps) {
   const { t } = useTranslation()
+
+  const selectedItem = items.find((i) => i.cartItemId === selectedItemId)
+  const numpadDisplay = numpadInput || (selectedItem ? String(selectedItem.quantity) : '')
 
   return (
     <div className='flex h-full flex-col'>
@@ -33,14 +49,24 @@ export function PosCart({
         ) : (
           items.map((item) => (
             <PosCartItem
-              key={item.productId}
+              key={item.cartItemId}
               item={item}
               onQuantityChange={onQuantityChange}
               onRemove={onRemoveItem}
+              isSelected={item.cartItemId === selectedItemId}
+              onSelect={onItemSelect}
             />
           ))
         )}
       </div>
+
+      <PosNumpad
+        displayValue={numpadDisplay}
+        onDigit={onNumpadDigit}
+        onBackspace={onNumpadBackspace}
+        onClear={onNumpadClear}
+        disabled={selectedItemId === null || items.length === 0}
+      />
 
       <div className='mt-auto border-t px-4 pt-3 pb-4'>
         <div className='space-y-1 text-sm'>

--- a/app/features/pos/components/PosCartItem.tsx
+++ b/app/features/pos/components/PosCartItem.tsx
@@ -1,27 +1,47 @@
 import { Minus, Plus, Trash2 } from 'lucide-react'
 import { Button } from '~/components/ui/button'
+import { cn } from '~/lib/utils'
 import { useTranslation } from '~/i18n/context'
 import type { CartItem } from '../types'
 import { calculateLineTotals } from '../types'
 
 interface PosCartItemProps {
   item: CartItem
-  onQuantityChange: (productId: string, quantity: number) => void
-  onRemove: (productId: string) => void
+  onQuantityChange: (cartItemId: string, quantity: number) => void
+  onRemove: (cartItemId: string) => void
+  isSelected?: boolean
+  onSelect?: (cartItemId: string) => void
 }
 
 export function PosCartItem({
   item,
   onQuantityChange,
   onRemove,
+  isSelected,
+  onSelect,
 }: PosCartItemProps) {
   const { t } = useTranslation()
   const { total } = calculateLineTotals(item)
 
+  const attrEntries = item.selectedAttributes
+    ? Object.entries(item.selectedAttributes)
+    : []
+
   return (
-    <div className='flex items-center gap-2 border-b py-2'>
+    <div
+      className={cn(
+        'flex items-center gap-2 border-b py-2 cursor-pointer rounded-sm px-1 -mx-1 transition-colors',
+        isSelected && 'bg-primary/10'
+      )}
+      onClick={() => onSelect?.(item.cartItemId)}
+    >
       <div className='min-w-0 flex-1'>
         <p className='truncate text-sm font-medium'>{item.productName}</p>
+        {attrEntries.length > 0 && (
+          <p className='text-muted-foreground truncate text-xs'>
+            {attrEntries.map(([, v]) => v).join(' · ')}
+          </p>
+        )}
         <p className='text-muted-foreground text-xs'>
           Q{item.unitPrice.toFixed(2)} {t('pos.perUnit')}
         </p>
@@ -30,9 +50,10 @@ export function PosCartItem({
         <Button
           variant='outline'
           size='icon-xs'
-          onClick={() =>
-            onQuantityChange(item.productId, Math.max(1, item.quantity - 1))
-          }
+          onClick={(e) => {
+            e.stopPropagation()
+            onQuantityChange(item.cartItemId, Math.max(1, item.quantity - 1))
+          }}
         >
           <Minus />
         </Button>
@@ -42,13 +63,14 @@ export function PosCartItem({
         <Button
           variant='outline'
           size='icon-xs'
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation()
             const max =
               item.productType === 'STOCK' && item.stock !== null
                 ? item.stock
                 : Infinity
             if (item.quantity < max) {
-              onQuantityChange(item.productId, item.quantity + 1)
+              onQuantityChange(item.cartItemId, item.quantity + 1)
             }
           }}
         >
@@ -62,7 +84,10 @@ export function PosCartItem({
         variant='ghost'
         size='icon-xs'
         className='text-destructive'
-        onClick={() => onRemove(item.productId)}
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove(item.cartItemId)
+        }}
       >
         <Trash2 />
       </Button>

--- a/app/features/pos/components/PosNumpad.tsx
+++ b/app/features/pos/components/PosNumpad.tsx
@@ -1,0 +1,76 @@
+import { Delete } from 'lucide-react'
+import { Button } from '~/components/ui/button'
+import { cn } from '~/lib/utils'
+
+interface PosNumpadProps {
+  displayValue: string
+  onDigit: (d: string) => void
+  onBackspace: () => void
+  onClear: () => void
+  disabled: boolean
+}
+
+const KEYS = ['7', '8', '9', '4', '5', '6', '1', '2', '3'] as const
+
+export function PosNumpad({
+  displayValue,
+  onDigit,
+  onBackspace,
+  onClear,
+  disabled,
+}: PosNumpadProps) {
+  return (
+    <div
+      className={cn(
+        'border-t px-4 pt-3 pb-2 select-none',
+        disabled && 'pointer-events-none opacity-40'
+      )}
+    >
+      {/* Display */}
+      <div className='bg-muted mb-2 rounded-md px-3 py-2 text-right text-xl font-mono font-semibold tabular-nums'>
+        {displayValue || '--'}
+      </div>
+
+      {/* Grid */}
+      <div className='grid grid-cols-3 gap-1'>
+        {KEYS.map((k) => (
+          <Button
+            key={k}
+            variant='outline'
+            className='h-10 text-base font-medium'
+            onClick={() => onDigit(k)}
+            disabled={disabled}
+          >
+            {k}
+          </Button>
+        ))}
+
+        {/* Bottom row: ⌫ 0 C */}
+        <Button
+          variant='outline'
+          className='h-10'
+          onClick={onBackspace}
+          disabled={disabled}
+        >
+          <Delete className='size-4' />
+        </Button>
+        <Button
+          variant='outline'
+          className='h-10 text-base font-medium'
+          onClick={() => onDigit('0')}
+          disabled={disabled}
+        >
+          0
+        </Button>
+        <Button
+          variant='outline'
+          className='h-10 text-base font-medium text-destructive'
+          onClick={onClear}
+          disabled={disabled}
+        >
+          C
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/features/pos/components/PosProductAttributesDialog.tsx
+++ b/app/features/pos/components/PosProductAttributesDialog.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { cn } from '~/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { Button } from '~/components/ui/button'
+import type { PosProductForGrid, ProductAttribute, ProductAttributeValue } from '../types'
+
+interface PosProductAttributesDialogProps {
+  product: PosProductForGrid | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (
+    product: PosProductForGrid,
+    selectedAttributes: Record<string, string>,
+    priceAdjustment: number
+  ) => void
+}
+
+export function PosProductAttributesDialog({
+  product,
+  open,
+  onOpenChange,
+  onConfirm,
+}: PosProductAttributesDialogProps) {
+  const [selected, setSelected] = useState<Record<string, string>>({})
+
+  if (!product) return null
+
+  const attributes = product.attributesJson?.attributes ?? []
+
+  const handleSelect = (attrKey: string, value: string) => {
+    setSelected((prev) => ({ ...prev, [attrKey]: value }))
+  }
+
+  const totalPriceAdjustment = attributes.reduce((sum, attr) => {
+    const selectedValue = selected[attr.key]
+    if (!selectedValue) return sum
+    const val = attr.values.find((v) => v.label === selectedValue)
+    return sum + (val?.priceAdjustment ?? 0)
+  }, 0)
+
+  const allSelected = attributes.every((attr) => selected[attr.key])
+
+  const handleConfirm = () => {
+    if (!allSelected) return
+    onConfirm(product, selected, totalPriceAdjustment)
+    setSelected({})
+    onOpenChange(false)
+  }
+
+  const handleDiscard = () => {
+    setSelected({})
+    onOpenChange(false)
+  }
+
+  const totalPrice = Number(product.price) + totalPriceAdjustment
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>
+            {product.name}{' '}
+            <span className='text-primary font-bold'>
+              Q{totalPrice.toFixed(2)}
+            </span>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-5 py-2'>
+          {attributes.map((attr) => (
+            <AttributeSection
+              key={attr.key}
+              attr={attr}
+              selectedValue={selected[attr.key]}
+              onSelect={(val) => handleSelect(attr.key, val)}
+            />
+          ))}
+        </div>
+
+        <div className='flex gap-3 pt-2'>
+          <Button
+            className='flex-1'
+            onClick={handleConfirm}
+            disabled={!allSelected}
+          >
+            Añadir al carrito
+          </Button>
+          <Button variant='outline' className='flex-1' onClick={handleDiscard}>
+            Descartar
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function AttributeSection({
+  attr,
+  selectedValue,
+  onSelect,
+}: {
+  attr: ProductAttribute
+  selectedValue?: string
+  onSelect: (val: string) => void
+}) {
+  return (
+    <div>
+      <p className='mb-2 text-sm font-semibold'>{attr.name}</p>
+      <div className='flex flex-wrap gap-2'>
+        {attr.values.map((val) => (
+          <AttributeValueButton
+            key={val.label}
+            value={val}
+            type={attr.type}
+            isSelected={selectedValue === val.label}
+            onSelect={() => onSelect(val.label)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function AttributeValueButton({
+  value,
+  type,
+  isSelected,
+  onSelect,
+}: {
+  value: ProductAttributeValue
+  type: 'button' | 'color'
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  if (type === 'color') {
+    return (
+      <button
+        type='button'
+        onClick={onSelect}
+        title={value.label}
+        className={cn(
+          'h-9 w-9 rounded-full border-2 transition-all',
+          isSelected ? 'border-primary scale-110 shadow-md' : 'border-transparent hover:border-muted-foreground/50'
+        )}
+        style={{ backgroundColor: value.hex ?? '#ccc' }}
+      />
+    )
+  }
+
+  const hasAdjustment = value.priceAdjustment && value.priceAdjustment > 0
+
+  return (
+    <button
+      type='button'
+      onClick={onSelect}
+      className={cn(
+        'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+        isSelected
+          ? 'bg-primary text-primary-foreground border-primary'
+          : 'bg-background hover:bg-muted border-input'
+      )}
+    >
+      {value.label}
+      {hasAdjustment && (
+        <span
+          className={cn(
+            'rounded-full px-1.5 py-0.5 text-xs font-semibold',
+            isSelected
+              ? 'bg-primary-foreground/20 text-primary-foreground'
+              : 'bg-primary/10 text-primary'
+          )}
+        >
+          +{value.priceAdjustment?.toFixed(2)} Q
+        </span>
+      )}
+    </button>
+  )
+}

--- a/app/features/pos/components/PosProductGrid.tsx
+++ b/app/features/pos/components/PosProductGrid.tsx
@@ -97,15 +97,28 @@ export function PosProductGrid({
                 <span
                   className={cn(
                     'mt-0.5 text-xs',
-                    isLowStock
-                      ? 'font-medium text-amber-600 dark:text-amber-400'
-                      : 'text-muted-foreground'
+                    isOutOfStock
+                      ? 'text-red-500 dark:text-red-400'
+                      : isLowStock
+                        ? 'font-medium text-amber-600 dark:text-amber-400'
+                        : 'text-muted-foreground'
                   )}
                 >
                   {t('pos.stock')}: {displayStock ?? 0}
                   {isLowStock && ' ⚠'}
                 </span>
               )}
+              {product.productType === 'STOCK' &&
+                isOutOfStock &&
+                product.otherSucursalesStock &&
+                product.otherSucursalesStock.length > 0 && (
+                  <span className='mt-0.5 text-xs text-blue-600 dark:text-blue-400'>
+                    📦{' '}
+                    {product.otherSucursalesStock
+                      .map((s) => `${s.name} (${s.stock})`)
+                      .join(', ')}
+                  </span>
+                )}
             </button>
           )
         })}

--- a/app/features/pos/schemas.ts
+++ b/app/features/pos/schemas.ts
@@ -18,6 +18,7 @@ export const createTerminalSchema = insertTerminalSchema
     name: z.string().min(1, 'Terminal name is required'),
     organizationId: z.string().uuid(),
     sucursalId: z.string().uuid().optional().nullable(),
+    companyId: z.string().uuid().optional().nullable(),
   })
 
 export const updateTerminalSchema = createTerminalSchema.partial()
@@ -52,6 +53,7 @@ export const checkoutSchema = z.object({
   terminalId: z.string().uuid(),
   organizationId: z.string().uuid(),
   sucursalId: z.string().uuid().optional().nullable(),
+  companyId: z.string().uuid().optional().nullable(),
   cashierId: z.string().uuid(),
   userId: z.string().uuid().optional().nullable(),
   businessPartnerId: z.string().uuid(),

--- a/app/features/pos/server/actions/create-sale.action.ts
+++ b/app/features/pos/server/actions/create-sale.action.ts
@@ -120,6 +120,7 @@ export async function createSaleAction(input: CheckoutInput) {
       .values({
         organizationId: input.organizationId,
         sucursalId: input.sucursalId,
+        companyId: input.companyId ?? null,
         terminalId: input.terminalId,
         cashierId: input.cashierId,
         sessionId: input.sessionId,
@@ -273,9 +274,9 @@ async function generateInvoiceIfConfigured(
   const defaultAccountId = saleResult.defaultSalesAccountId
   if (!defaultAccountId) return
 
-  // Look up companyId from sucursal (required by invoice model)
-  let companyId: string | null = null
-  if (input.sucursalId) {
+  // Resolve companyId: prefer terminal's direct companyId, fall back to sucursal's company
+  let companyId: string | null = input.companyId ?? null
+  if (!companyId && input.sucursalId) {
     const [sucursal] = await db
       .select({ companyId: sucursalModel.companyId })
       .from(sucursalModel)

--- a/app/features/pos/server/repository.ts
+++ b/app/features/pos/server/repository.ts
@@ -1,4 +1,14 @@
-import { and, count, desc, eq, ilike, inArray, or, sql, type SQL } from 'drizzle-orm'
+import {
+  and,
+  count,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm'
 import { db } from '~/server/db'
 import {
   posTerminalModel,
@@ -12,8 +22,12 @@ import {
 } from '~/server/db/schemas/pos'
 import { productModel } from '~/server/db/schemas/products'
 import { productCategoryModel } from '~/server/db/schemas/productCategory'
-import { sucursalModel, sucursalInventoryModel } from '~/server/db/schemas/sucursal'
+import {
+  sucursalModel,
+  sucursalInventoryModel,
+} from '~/server/db/schemas/sucursal'
 import { businessPartnerModel } from '~/server/db/schemas/businessPartner'
+import { companyModel } from '~/server/db/schemas/company'
 import { userModel } from '~/server/db/schemas/auth'
 import type {
   CreateTerminalInput,
@@ -27,8 +41,16 @@ export class PosRepository {
   // ── Terminal CRUD ──
 
   async getTerminals(
-    organizationId: string
+    organizationId: string,
+    sucursalId?: string
   ): Promise<PosTerminalWithSucursal[]> {
+    const conditions: SQL[] = [
+      eq(posTerminalModel.organizationId, organizationId),
+    ]
+    if (sucursalId) {
+      conditions.push(eq(posTerminalModel.sucursalId, sucursalId))
+    }
+
     const terminals = await db
       .select({
         id: posTerminalModel.id,
@@ -39,10 +61,19 @@ export class PosRepository {
         sucursalId: posTerminalModel.sucursalId,
         sucursalName: sucursalModel.name,
         defaultBusinessPartnerId: posTerminalModel.defaultBusinessPartnerId,
+        companyId: posTerminalModel.companyId,
+        companyName: companyModel.name,
       })
       .from(posTerminalModel)
-      .leftJoin(sucursalModel, eq(posTerminalModel.sucursalId, sucursalModel.id))
-      .where(eq(posTerminalModel.organizationId, organizationId))
+      .leftJoin(
+        sucursalModel,
+        eq(posTerminalModel.sucursalId, sucursalModel.id)
+      )
+      .leftJoin(
+        companyModel,
+        eq(posTerminalModel.companyId, companyModel.id)
+      )
+      .where(and(...conditions))
       .orderBy(posTerminalModel.name)
 
     return terminals
@@ -60,9 +91,18 @@ export class PosRepository {
         autoPrintReceipt: posTerminalModel.autoPrintReceipt,
         defaultBusinessPartnerId: posTerminalModel.defaultBusinessPartnerId,
         sucursalName: sucursalModel.name,
+        companyId: posTerminalModel.companyId,
+        companyName: companyModel.name,
       })
       .from(posTerminalModel)
-      .leftJoin(sucursalModel, eq(posTerminalModel.sucursalId, sucursalModel.id))
+      .leftJoin(
+        sucursalModel,
+        eq(posTerminalModel.sucursalId, sucursalModel.id)
+      )
+      .leftJoin(
+        companyModel,
+        eq(posTerminalModel.companyId, companyModel.id)
+      )
       .where(eq(posTerminalModel.id, id))
       .limit(1)
 
@@ -126,9 +166,20 @@ export class PosRepository {
         categoryId: productModel.categoryId,
         categoryName: productCategoryModel.name,
         categoryColor: productCategoryModel.color,
+        attributesJson: sql<import('../types').ProductAttributesJson | null>`${productModel.attributesJson}`,
         sucursalStock: sucursalId
           ? sucursalInventoryModel.stock
           : sql<number | null>`null`,
+        otherSucursalesStock: sucursalId
+          ? sql<{ name: string; stock: number }[] | null>`(
+              SELECT json_agg(json_build_object('name', s.name, 'stock', si.stock))
+              FROM ${sucursalInventoryModel} si
+              JOIN ${sucursalModel} s ON s.id = si.sucursal_id
+              WHERE si.product_id = ${productModel.id}
+                AND si.sucursal_id != ${sucursalId}
+                AND si.stock > 0
+            )`
+          : sql<null>`null`,
       })
       .from(productModel)
       .leftJoin(
@@ -243,7 +294,7 @@ export class PosRepository {
         or(
           ilike(posSaleModel.saleNumber, `%${search}%`),
           ilike(businessPartnerModel.nit, `%${search}%`),
-          ilike(sql`CAST(${posSaleModel.total} AS TEXT)`, `%${search}%`),
+          ilike(sql`CAST(${posSaleModel.total} AS TEXT)`, `%${search}%`)
         )!
       )
     }
@@ -517,7 +568,13 @@ export class PosRepository {
     }
 
     const openingCash = Number(session.openingCashAmount)
-    return openingCash + totalCashSales - totalRefundMovements - totalWithdrawals + (totalDeposits - openingCash)
+    return (
+      openingCash +
+      totalCashSales -
+      totalRefundMovements -
+      totalWithdrawals +
+      (totalDeposits - openingCash)
+    )
   }
 
   // ── Cash movements ──

--- a/app/features/pos/types.ts
+++ b/app/features/pos/types.ts
@@ -1,4 +1,22 @@
+export interface ProductAttributeValue {
+  label: string
+  priceAdjustment?: number
+  hex?: string // for color swatches
+}
+
+export interface ProductAttribute {
+  name: string
+  key: string
+  type: 'button' | 'color'
+  values: ProductAttributeValue[]
+}
+
+export interface ProductAttributesJson {
+  attributes: ProductAttribute[]
+}
+
 export interface CartItem {
+  cartItemId: string // unique per cart line (allows same product with different attributes)
   productId: string
   productName: string
   productSku: string
@@ -9,6 +27,7 @@ export interface CartItem {
   ivaRate: number
   productType: 'STOCK' | 'MADE_TO_ORDER' | 'SERVICE'
   stock: number | null
+  selectedAttributes?: Record<string, string>
 }
 
 export interface CartTotals {
@@ -27,6 +46,13 @@ export interface PosTerminalWithSucursal {
   sucursalId: string | null
   sucursalName: string | null
   defaultBusinessPartnerId: string | null
+  companyId: string | null
+  companyName: string | null
+}
+
+export interface OtherSucursalStock {
+  name: string
+  stock: number
 }
 
 export interface PosProductForGrid {
@@ -41,9 +67,13 @@ export interface PosProductForGrid {
   categoryName: string | null
   categoryColor: string | null
   sucursalStock: number | null
+  otherSucursalesStock: OtherSucursalStock[] | null
+  attributesJson: ProductAttributesJson | null
 }
 
-export function calculateLineTotals(item: CartItem) {
+export type CartItemLike = Pick<CartItem, 'quantity' | 'unitPrice' | 'discountPercent' | 'ivaType' | 'ivaRate'> & { stock?: number | null }
+
+export function calculateLineTotals(item: CartItemLike) {
   const qty = item.quantity
   const price = item.unitPrice
   const grossSubtotal = qty * price

--- a/app/hooks/usePermissions.ts
+++ b/app/hooks/usePermissions.ts
@@ -66,7 +66,7 @@ export function useCanPerformAction(action: ActionKey): boolean {
 }
 
 /**
- * Get filtered navigation items based on user permissions
+ * Get filtered navigation items based on user permissions and module access
  * Super admins see all menus, regular users see only menus they have access to
  * @param allMenus - All available navigation items
  * @returns Filtered array of navigation items user can access
@@ -74,20 +74,26 @@ export function useCanPerformAction(action: ActionKey): boolean {
 export function useFilteredNavigation<
   T extends {
     section: string
+    moduleKey?: string
     icon: React.ElementType
     color: string
     items: Array<{ path: string; name: string; icon: React.ElementType }>
   },
 >(allMenus: T[]) {
-  const { permissions } = useAuth()
+  const { permissions, moduleAccess } = useAuth()
 
   // Super admin sees everything
   if (permissions.isSuperAdmin) {
     return allMenus
   }
 
-  // Filter menus by permission
+  // Filter menus by permission and module access
   const filtered = allMenus.filter((section) => {
+    // If section has a moduleKey, check module access first
+    if (section.moduleKey && !moduleAccess.includes(section.moduleKey as never)) {
+      return false
+    }
+
     const filteredItems = section.items.filter((item) => {
       const requiredPermissions = MENU_PERMISSIONS[item.path as MenuPath] || []
       const hasPermission = requiredPermissions.some((perm) =>

--- a/app/i18n/locales/en/sidebar.ts
+++ b/app/i18n/locales/en/sidebar.ts
@@ -51,4 +51,5 @@ export const sidebar = {
   'sidebar.items.posTerminals': 'Terminals',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Branch Inventory',
+  'sidebar.items.modules': 'Modules',
 } as const

--- a/app/i18n/locales/es/sidebar.ts
+++ b/app/i18n/locales/es/sidebar.ts
@@ -51,4 +51,5 @@ export const sidebar = {
   'sidebar.items.posTerminals': 'Terminales',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Inventario por Sucursal',
+  'sidebar.items.modules': 'Módulos',
 } as const

--- a/app/layout/AppLayout.tsx
+++ b/app/layout/AppLayout.tsx
@@ -1,3 +1,4 @@
+import { eq, and } from 'drizzle-orm'
 import { Outlet, redirect, useLocation, useNavigation } from 'react-router'
 import AppSidebar from '~/components/AppSidebar'
 import SiteHeader from '~/components/SiteHeader'
@@ -8,9 +9,12 @@ import type { Organization } from '~/features/organization/schemas'
 import { organizationRepository } from '~/features/organization/server/repository'
 import { getUserOrganizations } from '~/server/auth/organization.server'
 import { productsRepository } from '~/features/products/server/repository'
+import { modulesRepository } from '~/features/modules/server/repository'
 import { getUserPermissions } from '~/server/auth/permissions.server'
 import { requireAuth } from '~/server/auth/session.server'
 import { isSuperAdmin } from '~/server/permissions'
+import { db } from '~/server/db'
+import { memberModel } from '~/server/db/schemas/auth'
 import type { Route } from './+types/AppLayout'
 
 // Add loader to require authentication and load permissions
@@ -19,16 +23,37 @@ export async function loader({ request }: Route.LoaderArgs) {
   const userId = session.user.id
   const organizationId = session.session.activeOrganizationId
 
+  // Get memberId for module access lookup
+  const memberRow = organizationId
+    ? await db
+        .select({ id: memberModel.id })
+        .from(memberModel)
+        .where(
+          and(
+            eq(memberModel.userId, userId),
+            eq(memberModel.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0])
+    : null
+
+  const memberId = memberRow?.id ?? null
+
   // Fetch permissions, super admin status, and low stock count in parallel
-  const [permissions, isSuperAdminUser, lowStockCount] = await Promise.all([
-    organizationId
-      ? getUserPermissions(userId, organizationId)
-      : Promise.resolve([]),
-    isSuperAdmin(userId),
-    organizationId
-      ? productsRepository.countLowStock(organizationId)
-      : Promise.resolve(0),
-  ])
+  const [permissions, isSuperAdminUser, lowStockCount, moduleAccess] =
+    await Promise.all([
+      organizationId
+        ? getUserPermissions(userId, organizationId)
+        : Promise.resolve([]),
+      isSuperAdmin(userId),
+      organizationId
+        ? productsRepository.countLowStock(organizationId)
+        : Promise.resolve(0),
+      memberId && organizationId
+        ? modulesRepository.getAccessibleModulesForMember(memberId, organizationId)
+        : Promise.resolve([]),
+    ])
 
   // Fetch all organizations for super admin, or just user's organizations
   let organizations: Organization[] = []
@@ -61,6 +86,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
     organizations,
     lowStockCount,
+    moduleAccess,
   }
 }
 
@@ -77,6 +103,7 @@ export default function AppLayout({ loaderData }: Route.ComponentProps) {
         session: loaderData.session,
         permissions: loaderData.permissions,
         availableOrganizations: loaderData.organizations,
+        moduleAccess: loaderData.moduleAccess,
       }}
     >
       <SidebarProvider>

--- a/app/layout/PosLayout.tsx
+++ b/app/layout/PosLayout.tsx
@@ -83,6 +83,7 @@ export default function PosLayout({ loaderData }: Route.ComponentProps) {
         session: loaderData.session,
         permissions: loaderData.permissions,
         availableOrganizations: loaderData.organizations,
+        moduleAccess: [],
       }}
     >
       <div className='bg-background flex h-screen flex-col overflow-hidden'>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -49,6 +49,7 @@ export default [
       index('./routes/organization/index.tsx'),
       route('/new', './routes/organization/create.tsx'),
       route('/:slug', './routes/organization/show.tsx'),
+      route('/:slug/edit', './routes/organization/edit.tsx'),
     ]),
 
     // Products Routes
@@ -93,6 +94,7 @@ export default [
       index('./routes/users/index.tsx'),
       route('/invite', './routes/users/invite.tsx'),
       route('/:memberId/roles', './routes/users/$memberId.roles.tsx'),
+      route('/:memberId/module-permissions', './routes/users/$memberId.module-permissions.tsx'),
     ]),
 
     // Roles Routes
@@ -116,6 +118,7 @@ export default [
     // Settings Routes
     ...prefix('settings', [
       route('/accounting', './routes/settings/accounting.tsx'),
+      route('/modules', './routes/settings/modules.tsx'),
     ]),
 
     // Dashboard Routes

--- a/app/routes/organization/create.tsx
+++ b/app/routes/organization/create.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Form, useActionData, useNavigation } from 'react-router'
 import { useTranslation } from '~/i18n/context'
 import { getLocaleFromRequest, translateServer } from '~/i18n/translate.server'
@@ -6,9 +7,10 @@ import { redirectWithFlash } from '~/server/flash.server'
 import { createOrganization } from '../../features/organization/server/actions/create.action'
 import type { Route } from './+types/create'
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader({ request, context }: Route.LoaderArgs) {
   await requireAuth(request)
-  return {}
+  const appDomain = context.cloudflare.env.APP_DOMAIN ?? 'bizops.app'
+  return { appDomain }
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -24,22 +26,61 @@ export async function action({ request }: Route.ActionArgs) {
   return response
 }
 
-export default function CreateOrganization() {
+export default function CreateOrganization({ loaderData }: Route.ComponentProps) {
   const actionData = useActionData<typeof createOrganization>()
   const navigation = useNavigation()
   const { t } = useTranslation()
+  const { appDomain } = loaderData
+
+  const [logoPreview, setLogoPreview] = useState<string | null>(null)
+  const [domain, setDomain] = useState('')
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => setLogoPreview(reader.result as string)
+      reader.readAsDataURL(file)
+    } else {
+      setLogoPreview(null)
+    }
+  }
 
   return (
     <div className='self-stretch p-6'>
       <div className='mx-auto max-w-2xl'>
         <h1 className='text-2xl font-bold'>{t('organization.createNew')}</h1>
 
-        <Form method='post' className='space-y-6'>
+        <Form method='post' encType='multipart/form-data' className='space-y-6'>
           {actionData?.message && (
             <div className='bg-destructive/10 text-destructive rounded-md p-4 text-sm'>
               {actionData.message}
             </div>
           )}
+
+          {/* Logo */}
+          <div>
+            <label htmlFor='logo' className='mb-2 block text-sm font-medium'>
+              Logo
+            </label>
+            <div className='flex items-center gap-4'>
+              {logoPreview && (
+                <img
+                  src={logoPreview}
+                  alt='Logo preview'
+                  className='h-16 w-16 rounded-full object-cover border'
+                />
+              )}
+              <input
+                type='file'
+                id='logo'
+                name='logo'
+                accept='image/*'
+                onChange={handleLogoChange}
+                className='border-input bg-background text-sm file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 rounded-md border px-3 py-2 w-full'
+              />
+            </div>
+          </div>
 
           <div>
             <label htmlFor='name' className='mb-2 block text-sm font-medium'>
@@ -74,6 +115,36 @@ export default function CreateOrganization() {
             <p className='text-muted-foreground mt-1 text-xs'>
               {t('organization.slugHelper')}
             </p>
+          </div>
+
+          {/* Domain */}
+          <div>
+            <label htmlFor='domain' className='mb-2 block text-sm font-medium'>
+              Dominio
+            </label>
+            <input
+              type='text'
+              id='domain'
+              name='domain'
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              placeholder='miempresa'
+              pattern='[a-z0-9-]+'
+              className='border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none'
+            />
+            {domain && (
+              <p className='text-muted-foreground mt-1 text-xs'>
+                Tu URL:{' '}
+                <span className='text-foreground font-medium'>
+                  https://{domain}.{appDomain}
+                </span>
+              </p>
+            )}
+            {!domain && (
+              <p className='text-muted-foreground mt-1 text-xs'>
+                Solo letras minúsculas, números y guiones. Ej: <code>mi-empresa</code>
+              </p>
+            )}
           </div>
 
           <div className='flex gap-3'>

--- a/app/routes/organization/edit.tsx
+++ b/app/routes/organization/edit.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react'
+import { Form, Link, redirect, useActionData, useNavigation } from 'react-router'
+import { Button } from '~/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card'
+import { updateOrganization } from '~/features/organization/server/actions/update.action'
+import { organizationRepository } from '~/features/organization/server/repository'
+import { getLocaleFromRequest, translateServer } from '~/i18n/translate.server'
+import { requireAuth } from '~/server/auth/session.server'
+import { redirectWithFlash } from '~/server/flash.server'
+import type { Route } from './+types/edit'
+
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  await requireAuth(request)
+  const { slug } = params
+
+  const organization = await organizationRepository.getBySlug(slug)
+  if (!organization) throw redirect('/organization')
+
+  const appDomain = context?.cloudflare?.env?.APP_DOMAIN ?? 'bizops.app'
+  return { organization, appDomain }
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const locale = getLocaleFromRequest(request)
+  const { slug } = params
+  const formData = await request.formData()
+
+  const result = await updateOrganization(slug, formData)
+
+  if (result.success) {
+    return redirectWithFlash(`/organization/${result.newSlug}`, {
+      type: 'success',
+      message: translateServer(locale, 'messages.organization.updated') ?? 'Organization updated.',
+    })
+  }
+
+  return result
+}
+
+export default function EditOrganization({ loaderData }: Route.ComponentProps) {
+  const { organization, appDomain } = loaderData
+  const actionData = useActionData<typeof action>()
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state === 'submitting'
+
+  const [logoPreview, setLogoPreview] = useState<string | null>(organization.logo ?? null)
+  const [domain, setDomain] = useState(organization.domain ?? '')
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => setLogoPreview(reader.result as string)
+      reader.readAsDataURL(file)
+    }
+  }
+
+  return (
+    <div className="p-6">
+      <div className="mx-auto max-w-2xl space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="mb-1 flex items-center gap-2 text-sm text-muted-foreground">
+              <Link to="/organization" className="hover:text-foreground transition-colors">
+                Organizations
+              </Link>
+              <span>/</span>
+              <Link
+                to={`/organization/${organization.slug}`}
+                className="hover:text-foreground transition-colors"
+              >
+                {organization.name}
+              </Link>
+              <span>/</span>
+              <span className="text-foreground">Edit</span>
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">Edit Organization</h1>
+          </div>
+        </div>
+
+        {actionData?.message && (
+          <div className="rounded-md bg-destructive/10 p-4 text-sm text-destructive">
+            {actionData.message}
+          </div>
+        )}
+
+        <Form method="post" encType="multipart/form-data">
+          {/* Keep current logo as fallback if no new file selected */}
+          <input type="hidden" name="currentLogo" value={organization.logo ?? ''} />
+
+          <Card className="rounded-xl shadow-sm">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Organization Info</CardTitle>
+              <CardDescription>Update name, slug, logo and domain.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {/* Logo */}
+              <div>
+                <label htmlFor="logo" className="mb-2 block text-sm font-medium">
+                  Logo
+                </label>
+                <div className="flex items-center gap-4">
+                  {logoPreview ? (
+                    <img
+                      src={logoPreview}
+                      alt="Logo preview"
+                      className="h-16 w-16 rounded-full border object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-16 w-16 items-center justify-center rounded-full border bg-muted text-xl font-semibold text-muted-foreground">
+                      {organization.name?.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <input
+                    type="file"
+                    id="logo"
+                    name="logo"
+                    accept="image/*"
+                    onChange={handleLogoChange}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                  />
+                </div>
+              </div>
+
+              {/* Name */}
+              <div>
+                <label htmlFor="name" className="mb-1.5 block text-sm font-medium">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  required
+                  defaultValue={organization.name ?? ''}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              </div>
+
+              {/* Slug */}
+              <div>
+                <label htmlFor="slug" className="mb-1.5 block text-sm font-medium">
+                  Slug
+                </label>
+                <input
+                  type="text"
+                  id="slug"
+                  name="slug"
+                  required
+                  defaultValue={organization.slug ?? ''}
+                  pattern="[a-z0-9-]+"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Only lowercase letters, numbers and hyphens. Changing this will update the URL.
+                </p>
+              </div>
+
+              {/* Domain */}
+              <div>
+                <label htmlFor="domain" className="mb-1.5 block text-sm font-medium">
+                  Domain
+                </label>
+                <input
+                  type="text"
+                  id="domain"
+                  name="domain"
+                  value={domain}
+                  onChange={(e) => setDomain(e.target.value)}
+                  placeholder="miempresa"
+                  pattern="[a-z0-9-]*"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+                {domain && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    URL:{' '}
+                    <span className="font-medium text-foreground">
+                      https://{domain}.{appDomain}
+                    </span>
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Footer actions */}
+          <div className="mt-6 flex items-center gap-3">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving…' : 'Save changes'}
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link to={`/organization/${organization.slug}`}>Cancel</Link>
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  )
+}

--- a/app/routes/organization/show.tsx
+++ b/app/routes/organization/show.tsx
@@ -1,18 +1,41 @@
-import { Link, useSubmit } from 'react-router'
+import { useState } from 'react'
+import { Link, useFetcher } from 'react-router'
 import { Button } from '~/components/ui/button'
-import { useTranslation } from '~/i18n/context'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '~/components/ui/alert-dialog'
 import { deleteOrganization } from '~/features/organization/server/actions/delete.action'
+import { modulesRepository } from '~/features/modules/server/repository'
 import { organizationRepository } from '~/features/organization/server/repository'
 import { getLocaleFromRequest, translateServer } from '~/i18n/translate.server'
+import { requireAuth } from '~/server/auth/session.server'
 import { redirectWithFlash } from '~/server/flash.server'
 import type { Route } from './+types/show'
 
-export async function loader({ params }: Route.LoaderArgs) {
+export async function loader({ params, request, context }: Route.LoaderArgs) {
+  const session = await requireAuth(request)
   const { slug } = params
 
   const organization = await organizationRepository.getBySlug(slug)
+  const appDomain = context?.cloudflare?.env?.APP_DOMAIN ?? 'bizops.app'
 
-  return { organization }
+  const activeModules = organization
+    ? await modulesRepository.getActiveModulesForOrg(organization.id)
+    : []
+
+  return {
+    organization,
+    appDomain,
+    activeModules,
+    canDelete: session.user.isSuperAdmin,
+  }
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -28,68 +51,190 @@ export async function action({ request, params }: Route.ActionArgs) {
   return result
 }
 
-export default function Show({ loaderData }: Route.ComponentProps) {
-  const { organization } = loaderData
-  const metadata = organization?.metadata ?? {}
-  const submit = useSubmit()
-  const { t } = useTranslation()
+function DeleteZone({
+  orgName,
+  activeModules,
+  actionError,
+}: {
+  orgName: string
+  activeModules: string[]
+  actionError?: string
+}) {
+  const fetcher = useFetcher()
+  const [confirmName, setConfirmName] = useState('')
+  const [open, setOpen] = useState(false)
 
-  const handleDelete = () => {
-    if (
-      confirm(
-        `Are you sure you want to delete "${organization?.name}"? This action cannot be undone.`
-      )
-    ) {
-      submit({}, { method: 'post' })
-    }
-  }
+  const hasBlockers = activeModules.length > 0
+  const isSubmitting = fetcher.state !== 'idle'
+  const fetcherError = fetcher.data?.message
 
   return (
-    <div className=''>
-      <div className='mb-6 flex items-center justify-between'>
-        <div>
-          <h1 className='text-2xl font-bold'>{t('organization.settings')}</h1>
-          <p className='text-muted-foreground'>
-            {t('organization.settingsDescription')}
-          </p>
-        </div>
-        <div>
-          <Button variant='destructive' onClick={handleDelete}>
-            {t('common.delete')}
-          </Button>
-          <Link to='/organization'>
-            <Button variant='ghost'>{t('common.cancel')}</Button>
-          </Link>
-        </div>
-      </div>
+    <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-6 shadow-sm">
+      <h2 className="mb-1 text-base font-semibold text-destructive">Danger Zone</h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Deleting an organization is permanent and cannot be undone.
+      </p>
 
-      {/* Logo and Basic Info */}
-      <div className='bg-card flex items-center gap-6 rounded-lg border p-6 shadow-sm'>
-        {organization?.logo && (
-          <img
-            src={organization.logo}
-            alt={organization.name || 'Organization'}
-            className='border-primary h-24 w-24 rounded-full border-2'
+      {(actionError || fetcherError) && (
+        <div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {actionError ?? fetcherError}
+        </div>
+      )}
+
+      {hasBlockers && (
+        <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/30">
+          <p className="mb-2 text-sm font-medium text-amber-800 dark:text-amber-400">
+            Cannot delete — active modules must be deactivated first:
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {activeModules.map((mod) => (
+              <span
+                key={mod}
+                className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/50 dark:text-amber-300"
+              >
+                {mod}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogTrigger asChild>
+          <Button variant="destructive" disabled={hasBlockers}>
+            Delete organization
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete &ldquo;{orgName}&rdquo;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action is permanent and cannot be undone. All data associated with this
+              organization will be removed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="my-2">
+            <label className="mb-1.5 block text-sm font-medium">
+              Type <span className="font-mono font-semibold">{orgName}</span> to confirm
+            </label>
+            <input
+              type="text"
+              value={confirmName}
+              onChange={(e) => setConfirmName(e.target.value)}
+              placeholder={orgName}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmName('')}>Cancel</AlertDialogCancel>
+            <fetcher.Form method="post" onSubmit={() => setOpen(false)}>
+              <Button
+                type="submit"
+                variant="destructive"
+                disabled={confirmName !== orgName || isSubmitting}
+              >
+                {isSubmitting ? 'Deleting…' : 'Yes, delete permanently'}
+              </Button>
+            </fetcher.Form>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+export default function Show({ loaderData }: Route.ComponentProps) {
+  const { organization, appDomain, activeModules, canDelete } = loaderData
+
+  return (
+    <div className="p-6">
+      <div className="mx-auto max-w-2xl space-y-6">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="mb-1 flex items-center gap-2 text-sm text-muted-foreground">
+              <Link to="/organization" className="hover:text-foreground transition-colors">
+                Organizations
+              </Link>
+              <span>/</span>
+              <span className="text-foreground">{organization?.name}</span>
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {organization?.name ?? 'Organization'}
+            </h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" asChild>
+              <Link to="edit">Edit</Link>
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link to="/organization">Back</Link>
+            </Button>
+          </div>
+        </div>
+
+        {/* Info card */}
+        <div className="rounded-xl bg-card p-6 shadow-sm">
+          <div className="flex items-center gap-5">
+            {organization?.logo ? (
+              <img
+                src={organization.logo}
+                alt={organization.name ?? 'Organization'}
+                className="h-20 w-20 rounded-full border object-cover"
+              />
+            ) : (
+              <div className="flex h-20 w-20 items-center justify-center rounded-full border bg-muted text-2xl font-semibold text-muted-foreground">
+                {organization?.name?.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold">{organization?.name}</h2>
+              <span className="inline-block rounded-full bg-muted px-2.5 py-0.5 font-mono text-xs text-muted-foreground">
+                {organization?.slug}
+              </span>
+              {organization?.domain && (
+                <div>
+                  <a
+                    href={`https://${organization.domain}.${appDomain}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline"
+                  >
+                    {organization.domain}.{appDomain}
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Active modules card */}
+        {activeModules.length > 0 && (
+          <div className="rounded-xl bg-card p-6 shadow-sm">
+            <h2 className="mb-3 text-base font-semibold">Active Modules</h2>
+            <div className="flex flex-wrap gap-2">
+              {activeModules.map((mod) => (
+                <span
+                  key={mod}
+                  className="rounded-full bg-green-500/10 px-3 py-1 text-xs font-medium text-green-700 dark:text-green-400"
+                >
+                  {mod}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Danger zone — super admin only */}
+        {canDelete && (
+          <DeleteZone
+            orgName={organization?.name ?? ''}
+            activeModules={activeModules}
           />
         )}
-        <div>
-          <h2 className='text-2xl font-bold'>
-            {organization?.name || 'Unknown User'}
-          </h2>
-          <p className='text-muted-foreground'>{organization?.slug}</p>
-        </div>
       </div>
-
-      {/* Raw User Data (for debugging) */}
-      <details className='bg-card rounded-lg border p-6 shadow-sm'>
-        <summary className='cursor-pointer text-lg font-semibold'>
-          {' '}
-          {t('organization.debugData')}
-        </summary>
-        <pre className='bg-muted mt-4 overflow-auto rounded p-4 text-xs'>
-          {JSON.stringify(metadata, null, 2)}
-        </pre>
-      </details>
     </div>
   )
 }

--- a/app/routes/pos-settings/terminals.tsx
+++ b/app/routes/pos-settings/terminals.tsx
@@ -1,5 +1,5 @@
 import { type ColumnDef } from '@tanstack/react-table'
-import { Plus, Trash2 } from 'lucide-react'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Form, useFetcher, useNavigation } from 'react-router'
 import { Badge } from '~/components/ui/badge'
@@ -22,7 +22,7 @@ import {
 } from '~/components/ui/select'
 import { Switch } from '~/components/ui/switch'
 import { posRepository } from '~/features/pos/server/repository'
-import { createTerminalSchema } from '~/features/pos/schemas'
+import { createTerminalSchema, updateTerminalSchema } from '~/features/pos/schemas'
 import { requireAuth } from '~/server/auth/session.server'
 import { useTranslation } from '~/i18n/context'
 import type { Route } from './+types/terminals'
@@ -30,6 +30,7 @@ import type { PosTerminalWithSucursal } from '~/features/pos/types'
 import { db } from '~/server/db'
 import { sucursalModel } from '~/server/db/schemas/sucursal'
 import { businessPartnerModel } from '~/server/db/schemas/businessPartner'
+import { companyModel } from '~/server/db/schemas/company'
 import { eq } from 'drizzle-orm'
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -40,7 +41,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     return { terminals: [], sucursales: [], businessPartners: [] }
   }
 
-  const [terminals, sucursales, businessPartners] = await Promise.all([
+  const [terminals, sucursales, businessPartners, companies] = await Promise.all([
     posRepository.getTerminals(organizationId),
     db
       .select({ id: sucursalModel.id, name: sucursalModel.name, code: sucursalModel.code })
@@ -55,9 +56,14 @@ export async function loader({ request }: Route.LoaderArgs) {
       })
       .from(businessPartnerModel)
       .where(eq(businessPartnerModel.organizationId, organizationId)),
+    db
+      .select({ id: companyModel.id, name: companyModel.name, nit: companyModel.nit })
+      .from(companyModel)
+      .where(eq(companyModel.organizationId, organizationId))
+      .orderBy(companyModel.name),
   ])
 
-  return { terminals, sucursales, businessPartners, organizationId }
+  return { terminals, sucursales, businessPartners, companies, organizationId }
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -70,6 +76,7 @@ export async function action({ request }: Route.ActionArgs) {
       name: formData.get('name'),
       organizationId: formData.get('organizationId'),
       sucursalId: formData.get('sucursalId') || null,
+      companyId: formData.get('companyId') || null,
       autoGenerateInvoice: formData.get('autoGenerateInvoice') === 'on',
       autoPrintReceipt: formData.get('autoPrintReceipt') === 'on',
       defaultBusinessPartnerId:
@@ -101,24 +108,48 @@ export async function action({ request }: Route.ActionArgs) {
     return { success: true }
   }
 
+  if (intent === 'update') {
+    const id = formData.get('id') as string
+    const data = {
+      name: formData.get('name'),
+      sucursalId: formData.get('sucursalId') || null,
+      companyId: formData.get('companyId') || null,
+      isActive: formData.get('isActive') === 'on',
+      autoGenerateInvoice: formData.get('autoGenerateInvoice') === 'on',
+      autoPrintReceipt: formData.get('autoPrintReceipt') === 'on',
+      defaultBusinessPartnerId:
+        formData.get('defaultBusinessPartnerId') || null,
+    }
+
+    const parsed = updateTerminalSchema.safeParse(data)
+    if (!parsed.success) {
+      return {
+        error: 'Validation failed',
+        fieldErrors: parsed.error.flatten().fieldErrors,
+      }
+    }
+
+    await posRepository.updateTerminal(id, parsed.data)
+    return { success: true, intent: 'update' }
+  }
+
   return { error: 'Unknown intent' }
 }
 
 export default function PosTerminals({ loaderData }: Route.ComponentProps) {
-  const { terminals, sucursales, businessPartners, organizationId } =
+  const { terminals, sucursales, businessPartners, companies, organizationId } =
     loaderData as {
       terminals: PosTerminalWithSucursal[]
       sucursales: Array<{ id: string; name: string; code: string }>
-      businessPartners: Array<{
-        id: string
-        name: string
-        nit: string | null
-      }>
+      businessPartners: Array<{ id: string; name: string; nit: string | null }>
+      companies: Array<{ id: string; name: string; nit: string }>
       organizationId?: string
     }
 
   const { t } = useTranslation()
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingTerminal, setEditingTerminal] =
+    useState<PosTerminalWithSucursal | null>(null)
   const fetcher = useFetcher()
   const navigation = useNavigation()
   const isSubmitting = navigation.state === 'submitting'
@@ -132,6 +163,11 @@ export default function PosTerminals({ loaderData }: Route.ComponentProps) {
       accessorKey: 'sucursalName',
       header: 'Sucursal',
       cell: ({ row }) => row.original.sucursalName ?? '-',
+    },
+    {
+      accessorKey: 'companyName',
+      header: 'Empresa',
+      cell: ({ row }) => row.original.companyName ?? '-',
     },
     {
       accessorKey: 'isActive',
@@ -174,18 +210,28 @@ export default function PosTerminals({ loaderData }: Route.ComponentProps) {
     {
       id: 'actions',
       cell: ({ row }) => (
-        <fetcher.Form method='post'>
-          <input type='hidden' name='intent' value='delete' />
-          <input type='hidden' name='id' value={row.original.id} />
+        <div className='flex items-center gap-1'>
           <Button
             variant='ghost'
             size='icon-xs'
-            type='submit'
-            className='text-destructive'
+            type='button'
+            onClick={() => setEditingTerminal(row.original)}
           >
-            <Trash2 className='size-4' />
+            <Pencil className='size-4' />
           </Button>
-        </fetcher.Form>
+          <fetcher.Form method='post'>
+            <input type='hidden' name='intent' value='delete' />
+            <input type='hidden' name='id' value={row.original.id} />
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              type='submit'
+              className='text-destructive'
+            >
+              <Trash2 className='size-4' />
+            </Button>
+          </fetcher.Form>
+        </div>
       ),
     },
   ]
@@ -206,6 +252,153 @@ export default function PosTerminals({ loaderData }: Route.ComponentProps) {
       </div>
 
       <DataTable columns={columns} data={terminals} />
+
+      <Dialog
+        open={!!editingTerminal}
+        onOpenChange={(open) => !open && setEditingTerminal(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Editar terminal</DialogTitle>
+          </DialogHeader>
+          {editingTerminal && (
+            <Form
+              method='post'
+              onSubmit={() => setTimeout(() => setEditingTerminal(null), 200)}
+            >
+              <input type='hidden' name='intent' value='update' />
+              <input type='hidden' name='id' value={editingTerminal.id} />
+
+              <div className='space-y-4'>
+                <div>
+                  <label className='text-sm font-medium'>
+                    {t('pos.terminalName')}
+                  </label>
+                  <Input
+                    name='name'
+                    defaultValue={editingTerminal.name}
+                    required
+                    className='mt-1'
+                  />
+                </div>
+
+                <div>
+                  <label className='text-sm font-medium'>Sucursal</label>
+                  <Select
+                    name='sucursalId'
+                    defaultValue={editingTerminal.sucursalId ?? undefined}
+                  >
+                    <SelectTrigger className='mt-1'>
+                      <SelectValue placeholder='Seleccionar sucursal (opcional)' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sucursales.map((s) => (
+                        <SelectItem key={s.id} value={s.id}>
+                          {s.name} ({s.code})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div>
+                  <label className='text-sm font-medium'>Empresa legal</label>
+                  <Select
+                    name='companyId'
+                    defaultValue={editingTerminal.companyId ?? undefined}
+                  >
+                    <SelectTrigger className='mt-1'>
+                      <SelectValue placeholder='Seleccionar empresa (opcional)' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {companies.map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.name} ({c.nit})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div>
+                  <label className='text-sm font-medium'>
+                    {t('pos.defaultCustomerLabel')}
+                  </label>
+                  <Select
+                    name='defaultBusinessPartnerId'
+                    defaultValue={
+                      editingTerminal.defaultBusinessPartnerId ?? undefined
+                    }
+                  >
+                    <SelectTrigger className='mt-1'>
+                      <SelectValue placeholder={t('pos.defaultCustomer')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {businessPartners.map((bp) => (
+                        <SelectItem key={bp.id} value={bp.id}>
+                          {bp.name} {bp.nit ? `(${bp.nit})` : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className='flex items-center gap-3'>
+                  <Switch
+                    name='isActive'
+                    id='edit-isActive'
+                    defaultChecked={editingTerminal.isActive}
+                  />
+                  <label htmlFor='edit-isActive' className='text-sm font-medium'>
+                    {t('common.active')}
+                  </label>
+                </div>
+
+                <div className='flex items-center gap-3'>
+                  <Switch
+                    name='autoGenerateInvoice'
+                    id='edit-autoInvoice'
+                    defaultChecked={editingTerminal.autoGenerateInvoice}
+                  />
+                  <label
+                    htmlFor='edit-autoInvoice'
+                    className='text-sm font-medium'
+                  >
+                    {t('pos.autoInvoice')}
+                  </label>
+                </div>
+
+                <div className='flex items-center gap-3'>
+                  <Switch
+                    name='autoPrintReceipt'
+                    id='edit-autoPrintReceipt'
+                    defaultChecked={editingTerminal.autoPrintReceipt}
+                  />
+                  <label
+                    htmlFor='edit-autoPrintReceipt'
+                    className='text-sm font-medium'
+                  >
+                    {t('pos.autoPrintReceipt')}
+                  </label>
+                </div>
+              </div>
+
+              <DialogFooter className='mt-6'>
+                <Button
+                  variant='outline'
+                  type='button'
+                  onClick={() => setEditingTerminal(null)}
+                >
+                  {t('common.cancel')}
+                </Button>
+                <Button type='submit' disabled={isSubmitting}>
+                  {isSubmitting ? t('common.saving') : t('common.save')}
+                </Button>
+              </DialogFooter>
+            </Form>
+          )}
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent>
@@ -244,6 +437,22 @@ export default function PosTerminals({ loaderData }: Route.ComponentProps) {
                     {sucursales.map((s) => (
                       <SelectItem key={s.id} value={s.id}>
                         {s.name} ({s.code})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <label className='text-sm font-medium'>Empresa legal</label>
+                <Select name='companyId'>
+                  <SelectTrigger className='mt-1'>
+                    <SelectValue placeholder='Seleccionar empresa (opcional)' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {companies.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name} ({c.nit})
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/app/routes/pos/index.tsx
+++ b/app/routes/pos/index.tsx
@@ -52,7 +52,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
-  const terminals = await posRepository.getTerminals(organizationId)
+  const terminals = await posRepository.getTerminals(
+    organizationId,
+    posSession?.sucursalId ?? undefined
+  )
   return { terminals, userName, hasUserSession: !!userSession }
 }
 
@@ -111,7 +114,7 @@ export default function PosIndex({ loaderData }: Route.ComponentProps) {
               <Link to='/dashboard'>Volver al ERP</Link>
             </Button>
           )}
-          <Form method='post' action='/logout'>
+          <Form method='post' action='/pos-logout'>
             <Button
               variant='ghost'
               size='sm'

--- a/app/routes/pos/terminal.tsx
+++ b/app/routes/pos/terminal.tsx
@@ -23,6 +23,7 @@ import { PosOpenShiftDialog } from '~/features/pos/components/PosOpenShiftDialog
 import { PosCloseShiftDialog } from '~/features/pos/components/PosCloseShiftDialog'
 import { PosCashMovementDialog } from '~/features/pos/components/PosCashMovementDialog'
 import { PosCreateCustomerDialog } from '~/features/pos/components/PosCreateCustomerDialog'
+import { PosProductAttributesDialog } from '~/features/pos/components/PosProductAttributesDialog'
 import type { ReceiptData } from '~/features/pos/components/PosReceiptPreview'
 import { PosReceiptContent } from '~/features/pos/components/PosReceiptContent'
 import {
@@ -356,6 +357,8 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
   const customerFetcher = useFetcher<typeof action>()
 
   const [cart, setCart] = useState<CartItem[]>([])
+  const [selectedCartItemId, setSelectedCartItemId] = useState<string | null>(null)
+  const [numpadInput, setNumpadInput] = useState('')
   const [search, setSearch] = useState('')
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
     null
@@ -372,6 +375,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
   const [closeShiftOpen, setCloseShiftOpen] = useState(false)
   const [cashMovementOpen, setCashMovementOpen] = useState(false)
   const [createCustomerOpen, setCreateCustomerOpen] = useState(false)
+  const [attributeDialogProduct, setAttributeDialogProduct] = useState<PosProductForGrid | null>(null)
 
   // No cashier profile
   if (!cashier) {
@@ -400,63 +404,154 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
 
   const totals = calculateCartTotals(cart)
 
-  const addToCart = useCallback((product: PosProductForGrid) => {
-    setCart((prev) => {
-      const existing = prev.find((item) => item.productId === product.id)
-      if (existing) {
-        const max =
-          product.productType === 'STOCK' && product.stock !== null
-            ? product.stock
-            : Infinity
-        if (existing.quantity >= max) return prev
-        return prev.map((item) =>
-          item.productId === product.id
-            ? { ...item, quantity: item.quantity + 1 }
-            : item
+  const addToCart = useCallback(
+    (
+      product: PosProductForGrid,
+      selectedAttributes?: Record<string, string>,
+      priceAdjustment = 0
+    ) => {
+      const attrsKey = selectedAttributes ? JSON.stringify(selectedAttributes) : ''
+      setCart((prev) => {
+        const existing = prev.find(
+          (item) =>
+            item.productId === product.id &&
+            JSON.stringify(item.selectedAttributes ?? {}) === attrsKey
         )
+        if (existing) {
+          const max =
+            product.productType === 'STOCK' && product.stock !== null
+              ? product.stock
+              : Infinity
+          if (existing.quantity >= max) return prev
+          setSelectedCartItemId(existing.cartItemId)
+          return prev.map((item) =>
+            item.cartItemId === existing.cartItemId
+              ? { ...item, quantity: item.quantity + 1 }
+              : item
+          )
+        }
+        const newCartItemId = crypto.randomUUID()
+        setSelectedCartItemId(newCartItemId)
+        return [
+          ...prev,
+          {
+            cartItemId: newCartItemId,
+            productId: product.id,
+            productName: product.name,
+            productSku: product.sku,
+            unitPrice: Number(product.price) + priceAdjustment,
+            quantity: 1,
+            discountPercent: 0,
+            ivaType: 'taxed' as const,
+            ivaRate: 12,
+            productType: product.productType as 'STOCK' | 'MADE_TO_ORDER' | 'SERVICE',
+            stock: product.stock,
+            selectedAttributes,
+          },
+        ]
+      })
+      setNumpadInput('')
+    },
+    []
+  )
+
+  const handleProductClick = useCallback(
+    (product: PosProductForGrid) => {
+      if (product.attributesJson?.attributes?.length) {
+        setAttributeDialogProduct(product)
+      } else {
+        addToCart(product)
       }
-      return [
-        ...prev,
-        {
-          productId: product.id,
-          productName: product.name,
-          productSku: product.sku,
-          unitPrice: Number(product.price),
-          quantity: 1,
-          discountPercent: 0,
-          ivaType: 'taxed' as const,
-          ivaRate: 12,
-          productType: product.productType as
-            | 'STOCK'
-            | 'MADE_TO_ORDER'
-            | 'SERVICE',
-          stock: product.stock,
-        },
-      ]
+    },
+    [addToCart]
+  )
+
+  const handleAttributesConfirm = useCallback(
+    (
+      product: PosProductForGrid,
+      selectedAttributes: Record<string, string>,
+      priceAdjustment: number
+    ) => {
+      addToCart(product, selectedAttributes, priceAdjustment)
+      setAttributeDialogProduct(null)
+    },
+    [addToCart]
+  )
+
+  const handleItemSelect = useCallback((cartItemId: string) => {
+    setSelectedCartItemId(cartItemId)
+    setNumpadInput('')
+  }, [])
+
+  const handleNumpadDigit = useCallback(
+    (digit: string) => {
+      if (!selectedCartItemId) return
+      setNumpadInput((prev) => {
+        const next = prev.length >= 4 ? prev : prev + digit
+        const qty = parseInt(next, 10)
+        if (!isNaN(qty) && qty >= 1) {
+          setCart((items) =>
+            items.map((item) => {
+              if (item.cartItemId !== selectedCartItemId) return item
+              const max =
+                item.productType === 'STOCK' && item.stock !== null
+                  ? item.stock
+                  : Infinity
+              return { ...item, quantity: Math.min(qty, max) }
+            })
+          )
+        }
+        return next
+      })
+    },
+    [selectedCartItemId]
+  )
+
+  const handleNumpadBackspace = useCallback(() => {
+    if (!selectedCartItemId) return
+    setNumpadInput((prev) => {
+      const next = prev.slice(0, -1)
+      if (next !== '') {
+        const qty = parseInt(next, 10)
+        if (!isNaN(qty) && qty >= 1) {
+          setCart((items) =>
+            items.map((item) =>
+              item.cartItemId === selectedCartItemId
+                ? { ...item, quantity: qty }
+                : item
+            )
+          )
+        }
+      }
+      return next
     })
+  }, [selectedCartItemId])
+
+  const handleNumpadClear = useCallback(() => {
+    setNumpadInput('')
   }, [])
 
   const handleQuantityChange = useCallback(
-    (productId: string, quantity: number) => {
+    (cartItemId: string, quantity: number) => {
       setCart((prev) =>
         prev.map((item) =>
-          item.productId === productId ? { ...item, quantity } : item
+          item.cartItemId === cartItemId ? { ...item, quantity } : item
         )
       )
     },
     []
   )
 
-  const handleRemoveItem = useCallback((productId: string) => {
-    setCart((prev) => prev.filter((item) => item.productId !== productId))
+  const handleRemoveItem = useCallback((cartItemId: string) => {
+    setCart((prev) => prev.filter((item) => item.cartItemId !== cartItemId))
   }, [])
 
   const handleBarcodeScan = useCallback(
     (barcode: string) => {
       const product = initialProducts.find((p) => p.sku === barcode)
-      if (product) addToCart(product)
+      if (product) handleProductClick(product)
     },
-    [initialProducts, addToCart]
+    [initialProducts, handleProductClick]
   )
 
   const handleCustomerSearch = useCallback(
@@ -484,6 +579,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
         terminalId: terminal.id,
         organizationId,
         sucursalId: terminal.sucursalId,
+        companyId: terminal.companyId,
         cashierId,
         userId,
         businessPartnerId,
@@ -612,6 +708,8 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
     processedSaleRef.current = receipt.saleNumber
     setReceiptData(receipt)
     setCart([])
+    setSelectedCartItemId(null)
+    setNumpadInput('')
     setSelectedCustomer(null)
     setPaymentOpen(false)
 
@@ -684,7 +782,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
             categories={categories}
             selectedCategoryId={selectedCategoryId}
             onCategoryChange={setSelectedCategoryId}
-            onProductClick={addToCart}
+            onProductClick={handleProductClick}
             sucursalId={terminal.sucursalId}
           />
         </div>
@@ -713,6 +811,12 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
             onQuantityChange={handleQuantityChange}
             onRemoveItem={handleRemoveItem}
             onCheckout={() => setPaymentOpen(true)}
+            selectedItemId={selectedCartItemId}
+            onItemSelect={handleItemSelect}
+            numpadInput={numpadInput}
+            onNumpadDigit={handleNumpadDigit}
+            onNumpadBackspace={handleNumpadBackspace}
+            onNumpadClear={handleNumpadClear}
           />
         </div>
       </div>
@@ -758,6 +862,13 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
         onOpenChange={setCreateCustomerOpen}
         onConfirm={handleCreateCustomer}
         isSubmitting={fetcher.state === 'submitting'}
+      />
+
+      <PosProductAttributesDialog
+        product={attributeDialogProduct}
+        open={attributeDialogProduct !== null}
+        onOpenChange={(open) => { if (!open) setAttributeDialogProduct(null) }}
+        onConfirm={handleAttributesConfirm}
       />
 
       {/*

--- a/app/routes/settings/modules.tsx
+++ b/app/routes/settings/modules.tsx
@@ -1,0 +1,151 @@
+import { ArrowLeft } from 'lucide-react'
+import { Form, Link, useNavigation } from 'react-router'
+import { Badge } from '~/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
+import { Switch } from '~/components/ui/switch'
+import { APP_MODULES, MODULE_META } from '~/features/modules/constants'
+import { toggleOrgModuleSchema } from '~/features/modules/schemas'
+import { modulesRepository } from '~/features/modules/server/repository'
+import { requireAuth } from '~/server/auth/session.server'
+import { isSuperAdmin } from '~/server/permissions'
+import { redirectWithFlash } from '~/server/flash.server'
+import type { Route } from './+types/modules'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const session = await requireAuth(request)
+  const organizationId = session.session.activeOrganizationId
+
+  if (!organizationId) {
+    return { orgModules: [], organizationId: null }
+  }
+
+  const orgModules = await modulesRepository.getOrgModules(organizationId)
+
+  return { orgModules, organizationId }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const session = await requireAuth(request)
+  const organizationId = session.session.activeOrganizationId
+
+  if (!organizationId) {
+    return { error: 'No organization selected' }
+  }
+
+  const superAdmin = await isSuperAdmin(session.user.id)
+  if (!superAdmin) {
+    return { error: 'Insufficient permissions' }
+  }
+
+  const formData = await request.formData()
+
+  const result = toggleOrgModuleSchema.safeParse({
+    organizationId: formData.get('organizationId'),
+    moduleKey: formData.get('moduleKey'),
+    isActive: formData.get('isActive'),
+  })
+
+  if (!result.success) {
+    return { error: 'Invalid data' }
+  }
+
+  await modulesRepository.setOrgModuleActive(
+    result.data.organizationId,
+    result.data.moduleKey,
+    result.data.isActive as boolean
+  )
+
+  return redirectWithFlash('/settings/modules', {
+    type: 'success',
+    message: 'Module updated successfully',
+  })
+}
+
+export default function ModulesSettingsPage({
+  loaderData,
+}: Route.ComponentProps) {
+  const { orgModules, organizationId } = loaderData
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state === 'submitting'
+
+  const activeModuleKeys = new Set(
+    orgModules.filter((m) => m.isActive).map((m) => m.moduleKey)
+  )
+
+  return (
+    <div className='mx-auto max-w-3xl space-y-6'>
+      <div className='flex items-center gap-4'>
+        <Link
+          to='/settings/accounting'
+          className='text-muted-foreground hover:text-foreground'
+        >
+          <ArrowLeft className='h-4 w-4' />
+        </Link>
+        <div>
+          <h1 className='text-2xl font-bold'>Módulos habilitados</h1>
+          <p className='text-muted-foreground text-sm'>
+            Activá o desactivá módulos para esta organización
+          </p>
+        </div>
+      </div>
+
+      {!organizationId && (
+        <div className='text-muted-foreground rounded-md border p-6 text-center text-sm'>
+          Seleccioná una organización para gestionar sus módulos.
+        </div>
+      )}
+
+      {organizationId && (
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+          {APP_MODULES.map((moduleKey) => {
+            const meta = MODULE_META[moduleKey]
+            const isActive = activeModuleKeys.has(moduleKey)
+            const Icon = meta.icon
+
+            return (
+              <Card key={moduleKey}>
+                <CardHeader className='flex flex-row items-start justify-between space-y-0 pb-2'>
+                  <div className='flex items-center gap-3'>
+                    <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
+                      <Icon className='text-primary h-5 w-5' />
+                    </div>
+                    <div>
+                      <CardTitle className='text-base'>{meta.label}</CardTitle>
+                      <Badge
+                        variant={isActive ? 'default' : 'secondary'}
+                        className='mt-1 text-xs'
+                      >
+                        {isActive ? 'Activo' : 'Inactivo'}
+                      </Badge>
+                    </div>
+                  </div>
+                  <Form method='post'>
+                    <input type='hidden' name='organizationId' value={organizationId} />
+                    <input type='hidden' name='moduleKey' value={moduleKey} />
+                    <input
+                      type='hidden'
+                      name='isActive'
+                      value={String(!isActive)}
+                    />
+                    <Switch
+                      checked={isActive}
+                      disabled={isSubmitting}
+                      onClick={(e) => {
+                        e.currentTarget.closest('form')?.requestSubmit()
+                      }}
+                    />
+                  </Form>
+                </CardHeader>
+                <CardContent>
+                  <p className='text-muted-foreground text-sm'>
+                    {meta.description}
+                  </p>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/routes/users/$memberId.module-permissions.tsx
+++ b/app/routes/users/$memberId.module-permissions.tsx
@@ -1,0 +1,211 @@
+import { eq } from 'drizzle-orm'
+import { Form, Link, redirect } from 'react-router'
+import { Button } from '~/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card'
+import { Label } from '~/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group'
+import {
+  APP_MODULES,
+  MODULE_META,
+  type ModuleAccessLevel,
+  type ModuleKey,
+} from '~/features/modules/constants'
+import { modulesRepository } from '~/features/modules/server/repository'
+import { requirePermission } from '~/server/auth/permissions.server'
+import { requireAuth } from '~/server/auth/session.server'
+import { db } from '~/server/db'
+import { memberModel, userModel } from '~/server/db/schemas/auth'
+import { redirectWithFlash } from '~/server/flash.server'
+import type { Route } from './+types/$memberId.module-permissions'
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const session = await requireAuth(request)
+  const url = new URL(request.url)
+  const organizationId =
+    url.searchParams.get('organizationId') ||
+    session.session.activeOrganizationId
+
+  if (!organizationId) {
+    throw redirect('/users')
+  }
+
+  await requirePermission(session.user.id, organizationId, 'user:update')
+
+  const memberId = params.memberId
+
+  const [member] = await db
+    .select({
+      id: memberModel.id,
+      userId: memberModel.userId,
+      organizationId: memberModel.organizationId,
+      userName: userModel.name,
+      userEmail: userModel.email,
+    })
+    .from(memberModel)
+    .innerJoin(userModel, eq(memberModel.userId, userModel.id))
+    .where(eq(memberModel.id, memberId))
+    .limit(1)
+
+  if (!member) {
+    throw redirect('/users')
+  }
+
+  const [memberAccess, activeOrgModules] = await Promise.all([
+    modulesRepository.getMemberModuleAccess(memberId, organizationId),
+    modulesRepository.getActiveModulesForOrg(organizationId),
+  ])
+
+  const accessMap: Record<string, ModuleAccessLevel> = {}
+  for (const row of memberAccess) {
+    accessMap[row.moduleKey] = row.accessLevel as ModuleAccessLevel
+  }
+
+  return { member, organizationId, activeOrgModules, accessMap }
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const session = await requireAuth(request)
+  const memberId = params.memberId
+  const formData = await request.formData()
+  const url = new URL(request.url)
+  const organizationId =
+    url.searchParams.get('organizationId') ||
+    session.session.activeOrganizationId
+
+  if (!organizationId) {
+    return { error: 'No organization selected' }
+  }
+
+  await requirePermission(session.user.id, organizationId, 'user:update')
+
+  const access: Partial<Record<ModuleKey, ModuleAccessLevel>> = {}
+  for (const moduleKey of APP_MODULES) {
+    const level = formData.get(`access_${moduleKey}`) as ModuleAccessLevel | null
+    access[moduleKey] = level ?? 'none'
+  }
+
+  await modulesRepository.setAllMemberModuleAccess(memberId, organizationId, access)
+
+  return redirectWithFlash(`/users?organizationId=${organizationId}`, {
+    type: 'success',
+    message: 'Module permissions updated successfully',
+  })
+}
+
+const ACCESS_LEVELS: { value: ModuleAccessLevel; label: string }[] = [
+  { value: 'none', label: 'Sin acceso' },
+  { value: 'user', label: 'Usuario' },
+  { value: 'admin', label: 'Administrador' },
+]
+
+export default function MemberModulePermissionsPage({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
+  const { member, organizationId, activeOrgModules, accessMap } = loaderData
+
+  return (
+    <div className='mx-auto max-w-2xl space-y-6'>
+      <div className='flex items-center gap-4'>
+        <Link
+          to={`/users?organizationId=${organizationId}`}
+          className='text-muted-foreground hover:text-foreground'
+        >
+          &larr; Volver
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Permisos de módulos — {member.userName}</CardTitle>
+          <CardDescription>
+            Configurá el nivel de acceso de {member.userEmail} por módulo.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {actionData?.error && (
+            <div className='bg-destructive/10 text-destructive mb-4 rounded-md p-3 text-sm'>
+              {actionData.error}
+            </div>
+          )}
+
+          {activeOrgModules.length === 0 && (
+            <div className='text-muted-foreground py-4 text-center text-sm'>
+              Esta organización no tiene módulos activos. Activá módulos en{' '}
+              <Link
+                to='/settings/modules'
+                className='text-primary underline'
+              >
+                Configuración → Módulos
+              </Link>
+              .
+            </div>
+          )}
+
+          <Form method='post'>
+            <div className='space-y-6'>
+              {activeOrgModules.map((moduleKey) => {
+                const meta = MODULE_META[moduleKey]
+                const Icon = meta.icon
+                const currentLevel = accessMap[moduleKey] ?? 'none'
+
+                return (
+                  <div key={moduleKey} className='rounded-lg border p-4'>
+                    <div className='mb-3 flex items-center gap-3'>
+                      <div className='bg-primary/10 flex h-8 w-8 items-center justify-center rounded-md'>
+                        <Icon className='text-primary h-4 w-4' />
+                      </div>
+                      <div>
+                        <p className='font-medium'>{meta.label}</p>
+                        <p className='text-muted-foreground text-xs'>
+                          {meta.description}
+                        </p>
+                      </div>
+                    </div>
+                    <RadioGroup
+                      name={`access_${moduleKey}`}
+                      defaultValue={currentLevel}
+                      className='flex gap-4'
+                    >
+                      {ACCESS_LEVELS.map((level) => (
+                        <div
+                          key={level.value}
+                          className='flex items-center gap-2'
+                        >
+                          <RadioGroupItem
+                            id={`${moduleKey}_${level.value}`}
+                            value={level.value}
+                          />
+                          <Label htmlFor={`${moduleKey}_${level.value}`}>
+                            {level.label}
+                          </Label>
+                        </div>
+                      ))}
+                    </RadioGroup>
+                  </div>
+                )
+              })}
+            </div>
+
+            {activeOrgModules.length > 0 && (
+              <div className='mt-6 flex gap-3'>
+                <Link to={`/users?organizationId=${organizationId}`}>
+                  <Button type='button' variant='outline'>
+                    Cancelar
+                  </Button>
+                </Link>
+                <Button type='submit'>Guardar permisos</Button>
+              </div>
+            )}
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/server/db/schemas/auth.ts
+++ b/app/server/db/schemas/auth.ts
@@ -70,6 +70,7 @@ export const organizationModel = pgTable('organization', {
   slug: text('slug').notNull().unique(),
   logo: text('logo'),
   metadata: text('metadata'),
+  domain: text('domain').unique(),
   isAdmin: boolean('is_admin').default(false).notNull(), // Identifies admin organizations that can create other orgs
   ...timestamps,
 })

--- a/app/server/db/schemas/index.ts
+++ b/app/server/db/schemas/index.ts
@@ -111,6 +111,12 @@ import {
   inventoryMovementRelations,
   inventoryMovementTypeEnum,
 } from './sucursal'
+import {
+  organizationModuleModel,
+  memberModuleAccessModel,
+  organizationModuleRelations,
+  memberModuleAccessRelations,
+} from './modules'
 
 export const schema = {
   // Auth tables
@@ -180,6 +186,10 @@ export const schema = {
   sucursalInventory: sucursalInventoryModel,
   inventoryMovement: inventoryMovementModel,
 
+  // Module tables
+  organizationModule: organizationModuleModel,
+  memberModuleAccess: memberModuleAccessModel,
+
   // Relations
   memberRelations,
   memberRoleRelations,
@@ -215,6 +225,8 @@ export const schema = {
   sucursalRelations,
   sucursalInventoryRelations,
   inventoryMovementRelations,
+  organizationModuleRelations,
+  memberModuleAccessRelations,
 }
 
 // Re-export all schemas for easy access
@@ -236,6 +248,7 @@ export * from './quotations'
 export * from './pos'
 export * from './sucursal'
 export * from './common'
+export * from './modules'
 
 // Re-export enums
 export {

--- a/app/server/db/schemas/modules.ts
+++ b/app/server/db/schemas/modules.ts
@@ -1,0 +1,61 @@
+import { relations } from 'drizzle-orm'
+import { boolean, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
+import { timestamps } from './common'
+import { memberModel, organizationModel } from './auth'
+
+export const organizationModuleModel = pgTable(
+  'organization_module',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id')
+      .notNull()
+      .references(() => organizationModel.id, { onDelete: 'cascade' }),
+    moduleKey: text('module_key').notNull(),
+    isActive: boolean('is_active').notNull().default(true),
+    activatedAt: timestamp('activated_at').notNull().defaultNow(),
+    expiresAt: timestamp('expires_at'),
+    ...timestamps,
+  },
+  (t) => [unique('org_module_unique').on(t.organizationId, t.moduleKey)]
+)
+
+export const memberModuleAccessModel = pgTable(
+  'member_module_access',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    memberId: uuid('member_id')
+      .notNull()
+      .references(() => memberModel.id, { onDelete: 'cascade' }),
+    organizationId: uuid('organization_id')
+      .notNull()
+      .references(() => organizationModel.id, { onDelete: 'cascade' }),
+    moduleKey: text('module_key').notNull(),
+    accessLevel: text('access_level').notNull().default('none'), // 'none' | 'user' | 'admin'
+    ...timestamps,
+  },
+  (t) => [unique('member_module_unique').on(t.memberId, t.moduleKey)]
+)
+
+export const organizationModuleRelations = relations(
+  organizationModuleModel,
+  ({ one }) => ({
+    organization: one(organizationModel, {
+      fields: [organizationModuleModel.organizationId],
+      references: [organizationModel.id],
+    }),
+  })
+)
+
+export const memberModuleAccessRelations = relations(
+  memberModuleAccessModel,
+  ({ one }) => ({
+    member: one(memberModel, {
+      fields: [memberModuleAccessModel.memberId],
+      references: [memberModel.id],
+    }),
+    organization: one(organizationModel, {
+      fields: [memberModuleAccessModel.organizationId],
+      references: [organizationModel.id],
+    }),
+  })
+)

--- a/app/server/db/schemas/pos.ts
+++ b/app/server/db/schemas/pos.ts
@@ -20,6 +20,7 @@ import type { z } from 'zod'
 import { organizationModel, userModel } from './auth'
 import { businessPartnerModel } from './businessPartner'
 import { timestamps } from './common'
+import { companyModel } from './company'
 import { invoiceModel, ivaTypeEnum } from './invoice'
 import { productModel } from './products'
 import { sucursalModel } from './sucursal'
@@ -67,6 +68,7 @@ export const posTerminalModel = pgTable('pos_terminal', {
   defaultBusinessPartnerId: uuid('default_business_partner_id').references(
     () => businessPartnerModel.id
   ),
+  companyId: uuid('company_id').references(() => companyModel.id),
   ...timestamps,
 }, (table) => [
   index('pos_terminal_org_active_idx').on(table.organizationId, table.isActive),
@@ -101,6 +103,7 @@ export const posSaleModel = pgTable('pos_sale', {
     .default('0'),
   total: numeric('total', { precision: 12, scale: 2 }).notNull(),
   currency: text('currency').notNull().default('GTQ'),
+  companyId: uuid('company_id').references(() => companyModel.id),
   invoiceId: uuid('invoice_id').references(() => invoiceModel.id),
   notes: text('notes'),
   ...timestamps,
@@ -273,6 +276,10 @@ export const posTerminalRelations = relations(
       fields: [posTerminalModel.defaultBusinessPartnerId],
       references: [businessPartnerModel.id],
     }),
+    company: one(companyModel, {
+      fields: [posTerminalModel.companyId],
+      references: [companyModel.id],
+    }),
     sales: many(posSaleModel),
     sessions: many(posSessionModel),
   })
@@ -298,6 +305,10 @@ export const posSaleRelations = relations(posSaleModel, ({ one, many }) => ({
   businessPartner: one(businessPartnerModel, {
     fields: [posSaleModel.businessPartnerId],
     references: [businessPartnerModel.id],
+  }),
+  company: one(companyModel, {
+    fields: [posSaleModel.companyId],
+    references: [companyModel.id],
   }),
   invoice: one(invoiceModel, {
     fields: [posSaleModel.invoiceId],

--- a/drizzle/0018_careful_stingray.sql
+++ b/drizzle/0018_careful_stingray.sql
@@ -1,4 +1,9 @@
-CREATE TYPE "public"."inventory_movement_type" AS ENUM('in', 'out', 'transfer_to_sucursal', 'transfer_from_sucursal', 'adjustment');--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."inventory_movement_type" AS ENUM('in', 'out', 'transfer_to_sucursal', 'transfer_from_sucursal', 'adjustment');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
 CREATE TABLE "inventory_movement" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"organization_id" uuid NOT NULL,

--- a/drizzle/0022_charming_tyrannus.sql
+++ b/drizzle/0022_charming_tyrannus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "organization" ADD COLUMN "domain" text;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_domain_unique" UNIQUE("domain");

--- a/drizzle/0023_dizzy_wasp.sql
+++ b/drizzle/0023_dizzy_wasp.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "member_module_access" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"member_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"module_key" text NOT NULL,
+	"access_level" text DEFAULT 'none' NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "member_module_unique" UNIQUE("member_id","module_key")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_module" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"module_key" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"activated_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "org_module_unique" UNIQUE("organization_id","module_key")
+);
+--> statement-breakpoint
+ALTER TABLE "member_module_access" ADD CONSTRAINT "member_module_access_member_id_member_id_fk" FOREIGN KEY ("member_id") REFERENCES "public"."member"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member_module_access" ADD CONSTRAINT "member_module_access_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_module" ADD CONSTRAINT "organization_module_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0024_rich_scarlet_spider.sql
+++ b/drizzle/0024_rich_scarlet_spider.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "pos_sale" ADD COLUMN "company_id" uuid;--> statement-breakpoint
+ALTER TABLE "pos_terminal" ADD COLUMN "company_id" uuid;--> statement-breakpoint
+ALTER TABLE "pos_sale" ADD CONSTRAINT "pos_sale_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pos_terminal" ADD CONSTRAINT "pos_terminal_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,5748 @@
+{
+  "id": "8fdb6778-1120-4d0a-a998-5b466a1aa1d9",
+  "prevId": "617a9366-269e-4c71-aa17-27e3cb542a21",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_account": {
+      "name": "accounting_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounting_account_organization_id_organization_id_fk": {
+          "name": "accounting_account_organization_id_organization_id_fk",
+          "tableFrom": "accounting_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_organization_id_organization_id_fk": {
+          "name": "appointment_organization_id_organization_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_client_id_business_partner_id_fk": {
+          "name": "appointment_client_id_business_partner_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_service_id_service_id_fk": {
+          "name": "appointment_service_id_service_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "service",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_staff_id_member_id_fk": {
+          "name": "appointment_staff_id_member_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "member",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_permissions": {
+          "name": "custom_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_role": {
+      "name": "invitation_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_role_invitation_id_invitation_id_fk": {
+          "name": "invitation_role_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_role_role_id_role_id_fk": {
+          "name": "invitation_role_role_id_role_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_role_unique": {
+          "name": "invitation_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_role_member_id_member_id_fk": {
+          "name": "member_role_member_id_member_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_role_role_id_role_id_fk": {
+          "name": "member_role_role_id_role_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_role_unique": {
+          "name": "member_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_domain_unique": {
+          "name": "organization_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission": {
+      "name": "permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_resource_action_idx": {
+          "name": "uq_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_organization_id_organization_id_fk": {
+          "name": "role_organization_id_organization_id_fk",
+          "tableFrom": "role",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission": {
+      "name": "role_permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permission_role_id_role_id_fk": {
+          "name": "role_permission_role_id_role_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_permission_id_permission_id_fk": {
+          "name": "role_permission_permission_id_permission_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "permission",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_organization_id_organization_id_fk": {
+          "name": "role_permission_organization_id_organization_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_partner": {
+      "name": "business_partner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_partner_email_org_idx": {
+          "name": "business_partner_email_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_partner_nit_org_idx": {
+          "name": "business_partner_nit_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_partner_organization_id_organization_id_fk": {
+          "name": "business_partner_organization_id_organization_id_fk",
+          "tableFrom": "business_partner",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_code_org_idx": {
+          "name": "company_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_organization_id_organization_id_fk": {
+          "name": "company_organization_id_organization_id_fk",
+          "tableFrom": "company",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "product_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STOCK'"
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_sku_org_idx": {
+          "name": "product_sku_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_org_type_idx": {
+          "name": "product_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_organization_id_organization_id_fk": {
+          "name": "product_organization_id_organization_id_fk",
+          "tableFrom": "product",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_category_id_product_category_id_fk": {
+          "name": "product_category_id_product_category_id_fk",
+          "tableFrom": "product",
+          "tableTo": "product_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_category": {
+      "name": "product_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "product_category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_category_org_name_idx": {
+          "name": "product_category_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_category_organization_id_organization_id_fk": {
+          "name": "product_category_organization_id_organization_id_fk",
+          "tableFrom": "product_category",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sat_file": {
+      "name": "sat_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_type": {
+          "name": "invoice_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_type": {
+          "name": "dte_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_number": {
+          "name": "dte_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitter_nit": {
+          "name": "emitter_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emitter_name": {
+          "name": "emitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_nit": {
+          "name": "receptor_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_name": {
+          "name": "receptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportation": {
+          "name": "exportation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "certificator_nit": {
+          "name": "certificator_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificator_name": {
+          "name": "certificator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "money": {
+          "name": "money",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva": {
+          "name": "iva",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_voided": {
+          "name": "is_voided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "voided_date": {
+          "name": "voided_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "petroleum": {
+          "name": "petroleum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "hotel": {
+          "name": "hotel",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tickets": {
+          "name": "tickets",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "press_stamp": {
+          "name": "press_stamp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "firefighters": {
+          "name": "firefighters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "municipal_tax": {
+          "name": "municipal_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "alcoholic_tax": {
+          "name": "alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tobacco_tax": {
+          "name": "tobacco_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cement_tax": {
+          "name": "cement_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "no_alcoholic_tax": {
+          "name": "no_alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "port_tariff_tax": {
+          "name": "port_tariff_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sat_file_unique_dte_idx": {
+          "name": "sat_file_unique_dte_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authorization_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serie",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sat_file_organization_id_organization_id_fk": {
+          "name": "sat_file_organization_id_organization_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_company_id_company_id_fk": {
+          "name": "sat_file_company_id_company_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_business_partner_id_business_partner_id_fk": {
+          "name": "sat_file_business_partner_id_business_partner_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_accounting_account_id_accounting_account_id_fk": {
+          "name": "sat_file_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line": {
+      "name": "invoice_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "invoice_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'goods'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_product_id_product_id_fk": {
+          "name": "invoice_line_product_id_product_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_file_id": {
+          "name": "sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "invoice_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'FCE'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'L'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_organization_id_organization_id_fk": {
+          "name": "invoice_organization_id_organization_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_company_id_company_id_fk": {
+          "name": "invoice_company_id_company_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_business_partner_id_business_partner_id_fk": {
+          "name": "invoice_business_partner_id_business_partner_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_accounting_account_id_accounting_account_id_fk": {
+          "name": "invoice_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_sat_file_id_sat_file_id_fk": {
+          "name": "invoice_sat_file_id_sat_file_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_line": {
+      "name": "journal_entry_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_amount": {
+          "name": "debit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "invoice_line_id": {
+          "name": "invoice_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_line_journal_entry_id_journal_entry_id_fk": {
+          "name": "journal_entry_line_journal_entry_id_journal_entry_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "journal_entry",
+          "columnsFrom": [
+            "journal_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_accounting_account_id_accounting_account_id_fk": {
+          "name": "journal_entry_line_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_invoice_line_id_invoice_line_id_fk": {
+          "name": "journal_entry_line_invoice_line_id_invoice_line_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "invoice_line",
+          "columnsFrom": [
+            "invoice_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry": {
+      "name": "journal_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_number": {
+          "name": "entry_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "journal_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_invoice_id": {
+          "name": "source_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sat_file_id": {
+          "name": "source_sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_pos_session_id": {
+          "name": "source_pos_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_debit": {
+          "name": "total_debit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_credit": {
+          "name": "total_credit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "journal_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_organization_id_organization_id_fk": {
+          "name": "journal_entry_organization_id_organization_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_company_id_company_id_fk": {
+          "name": "journal_entry_company_id_company_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_invoice_id_invoice_id_fk": {
+          "name": "journal_entry_source_invoice_id_invoice_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "source_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_sat_file_id_sat_file_id_fk": {
+          "name": "journal_entry_source_sat_file_id_sat_file_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "source_sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_posted_by_user_id_fk": {
+          "name": "journal_entry_posted_by_user_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "posted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_accounting_config": {
+      "name": "organization_accounting_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_credito_fiscal_account_id": {
+          "name": "iva_credito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iva_debito_fiscal_account_id": {
+          "name": "iva_debito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_receivable_account_id": {
+          "name": "accounts_receivable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_payable_account_id": {
+          "name": "accounts_payable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sales_account_id": {
+          "name": "default_sales_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_purchase_account_id": {
+          "name": "default_purchase_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_prefix": {
+          "name": "journal_entry_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JE'"
+        },
+        "next_journal_entry_number": {
+          "name": "next_journal_entry_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "manual_invoice_prefix": {
+          "name": "manual_invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "next_manual_invoice_number": {
+          "name": "next_manual_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "order_prefix": {
+          "name": "order_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OR'"
+        },
+        "next_order_number": {
+          "name": "next_order_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_prefix": {
+          "name": "pos_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POS'"
+        },
+        "next_pos_sale_number": {
+          "name": "next_pos_sale_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_cash_account_id": {
+          "name": "pos_cash_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_card_account_id": {
+          "name": "pos_card_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_check_account_id": {
+          "name": "pos_check_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_accounting_config_organization_id_organization_id_fk": {
+          "name": "organization_accounting_config_organization_id_organization_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_credito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_debito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_receivable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_payable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_sales_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_sales_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_sales_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_purchase_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_card_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_card_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_card_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_check_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_check_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_check_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_accounting_config_organization_id_unique": {
+          "name": "organization_accounting_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service": {
+      "name": "service",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "service_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "service_organization_id_organization_id_fk": {
+          "name": "service_organization_id_organization_id_fk",
+          "tableFrom": "service",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_movement": {
+      "name": "stock_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_date": {
+          "name": "movement_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stock_movement_organization_id_organization_id_fk": {
+          "name": "stock_movement_organization_id_organization_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_product_id_product_id_fk": {
+          "name": "stock_movement_product_id_product_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_created_by_id_user_id_fk": {
+          "name": "stock_movement_created_by_id_user_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_detail": {
+      "name": "order_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_detail_order_id_order_id_fk": {
+          "name": "order_detail_order_id_order_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_detail_product_id_product_id_fk": {
+          "name": "order_detail_product_id_product_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_organization_id_organization_id_fk": {
+          "name": "order_organization_id_organization_id_fk",
+          "tableFrom": "order",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_company_id_company_id_fk": {
+          "name": "order_company_id_company_id_fk",
+          "tableFrom": "order",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_business_partner_id_business_partner_id_fk": {
+          "name": "order_business_partner_id_business_partner_id_fk",
+          "tableFrom": "order",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_recipient": {
+      "name": "order_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_detail_id": {
+          "name": "order_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_recipient_order_detail_id_order_detail_id_fk": {
+          "name": "order_recipient_order_detail_id_order_detail_id_fk",
+          "tableFrom": "order_recipient",
+          "tableTo": "order_detail",
+          "columnsFrom": [
+            "order_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_detail": {
+      "name": "quotation_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_id": {
+          "name": "quotation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_detail_quotation_id_quotation_id_fk": {
+          "name": "quotation_detail_quotation_id_quotation_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "quotation",
+          "columnsFrom": [
+            "quotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_detail_product_id_product_id_fk": {
+          "name": "quotation_detail_product_id_product_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation": {
+      "name": "quotation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quotation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "quotation_date": {
+          "name": "quotation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotation_number": {
+          "name": "quotation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "converted_order_id": {
+          "name": "converted_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_organization_id_organization_id_fk": {
+          "name": "quotation_organization_id_organization_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_company_id_company_id_fk": {
+          "name": "quotation_company_id_company_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_business_partner_id_business_partner_id_fk": {
+          "name": "quotation_business_partner_id_business_partner_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_converted_order_id_order_id_fk": {
+          "name": "quotation_converted_order_id_order_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "order",
+          "columnsFrom": [
+            "converted_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_recipient": {
+      "name": "quotation_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_detail_id": {
+          "name": "quotation_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_recipient_quotation_detail_id_quotation_detail_id_fk": {
+          "name": "quotation_recipient_quotation_detail_id_quotation_detail_id_fk",
+          "tableFrom": "quotation_recipient",
+          "tableTo": "quotation_detail",
+          "columnsFrom": [
+            "quotation_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cash_movement": {
+      "name": "pos_cash_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pos_cash_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_cash_movement_session_id_pos_session_id_fk": {
+          "name": "pos_cash_movement_session_id_pos_session_id_fk",
+          "tableFrom": "pos_cash_movement",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cashier": {
+      "name": "pos_cashier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_attempts": {
+          "name": "pin_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pin_locked_at": {
+          "name": "pin_locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cashier_pin_org_idx": {
+          "name": "cashier_pin_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_cashier_organization_id_organization_id_fk": {
+          "name": "pos_cashier_organization_id_organization_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_cashier_user_id_user_id_fk": {
+          "name": "pos_cashier_user_id_user_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_payment": {
+      "name": "pos_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "pos_payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_amount": {
+          "name": "received_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_payment_sale_id_pos_sale_id_fk": {
+          "name": "pos_payment_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_payment",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale_line": {
+      "name": "pos_sale_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_percent": {
+          "name": "discount_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_sale_line_sale_id_pos_sale_id_fk": {
+          "name": "pos_sale_line_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pos_sale_line_product_id_product_id_fk": {
+          "name": "pos_sale_line_product_id_product_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale": {
+      "name": "pos_sale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sale_number": {
+          "name": "sale_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_sale_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_sale_idempotency_key_idx": {
+          "name": "pos_sale_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_terminal_created_idx": {
+          "name": "pos_sale_terminal_created_idx",
+          "columns": [
+            {
+              "expression": "terminal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_status_idx": {
+          "name": "pos_sale_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_org_created_idx": {
+          "name": "pos_sale_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_sale_organization_id_organization_id_fk": {
+          "name": "pos_sale_organization_id_organization_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_sucursal_id_sucursal_id_fk": {
+          "name": "pos_sale_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_sale_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_sale_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_business_partner_id_business_partner_id_fk": {
+          "name": "pos_sale_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_invoice_id_invoice_id_fk": {
+          "name": "pos_sale_invoice_id_invoice_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_session": {
+      "name": "pos_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_cash_amount": {
+          "name": "opening_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_cash_amount": {
+          "name": "closing_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash_amount": {
+          "name": "expected_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_session_organization_id_organization_id_fk": {
+          "name": "pos_session_organization_id_organization_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_sucursal_id_sucursal_id_fk": {
+          "name": "pos_session_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_session_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_session_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_terminal": {
+      "name": "pos_terminal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_generate_invoice": {
+          "name": "auto_generate_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_print_receipt": {
+          "name": "auto_print_receipt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_business_partner_id": {
+          "name": "default_business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_terminal_org_active_idx": {
+          "name": "pos_terminal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_terminal_organization_id_organization_id_fk": {
+          "name": "pos_terminal_organization_id_organization_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_sucursal_id_sucursal_id_fk": {
+          "name": "pos_terminal_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_default_business_partner_id_business_partner_id_fk": {
+          "name": "pos_terminal_default_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "default_business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_z_report": {
+      "name": "pos_z_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_name": {
+          "name": "terminal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_name": {
+          "name": "cashier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opening_cash": {
+          "name": "opening_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_cash": {
+          "name": "closing_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash": {
+          "name": "expected_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cash_difference": {
+          "name": "cash_difference",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sales": {
+          "name": "total_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cash_sales": {
+          "name": "total_cash_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_card_sales": {
+          "name": "total_card_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_check_sales": {
+          "name": "total_check_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_refunds": {
+          "name": "total_refunds",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_withdrawals": {
+          "name": "total_withdrawals",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deposits": {
+          "name": "total_deposits",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tax": {
+          "name": "total_tax",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_order_time": {
+          "name": "first_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_time": {
+          "name": "last_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_z_report_session_id_pos_session_id_fk": {
+          "name": "pos_z_report_session_id_pos_session_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_z_report_organization_id_organization_id_fk": {
+          "name": "pos_z_report_organization_id_organization_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pos_z_report_session_id_unique": {
+          "name": "pos_z_report_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_movement": {
+      "name": "inventory_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "inventory_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inventory_movement_org_idx": {
+          "name": "inventory_movement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_product_idx": {
+          "name": "inventory_movement_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_sucursal_idx": {
+          "name": "inventory_movement_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_movement_organization_id_organization_id_fk": {
+          "name": "inventory_movement_organization_id_organization_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_sucursal_id_sucursal_id_fk": {
+          "name": "inventory_movement_sucursal_id_sucursal_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_product_id_product_id_fk": {
+          "name": "inventory_movement_product_id_product_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal_inventory": {
+      "name": "sucursal_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_inventory_sucursal_product_idx": {
+          "name": "sucursal_inventory_sucursal_product_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_inventory_sucursal_idx": {
+          "name": "sucursal_inventory_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_inventory_sucursal_id_sucursal_id_fk": {
+          "name": "sucursal_inventory_sucursal_id_sucursal_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sucursal_inventory_product_id_product_id_fk": {
+          "name": "sucursal_inventory_product_id_product_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal": {
+      "name": "sucursal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_code_org_idx": {
+          "name": "sucursal_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_org_active_idx": {
+          "name": "sucursal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_organization_id_organization_id_fk": {
+          "name": "sucursal_organization_id_organization_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sucursal_company_id_company_id_fk": {
+          "name": "sucursal_company_id_company_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "cancelled",
+        "completed"
+      ]
+    },
+    "public.inventory_movement_type": {
+      "name": "inventory_movement_type",
+      "schema": "public",
+      "values": [
+        "in",
+        "out",
+        "transfer_to_sucursal",
+        "transfer_from_sucursal",
+        "adjustment"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.invoice_type": {
+      "name": "invoice_type",
+      "schema": "public",
+      "values": [
+        "purchase",
+        "sale"
+      ]
+    },
+    "public.iva_type": {
+      "name": "iva_type",
+      "schema": "public",
+      "values": [
+        "taxed",
+        "exempt",
+        "non_subject"
+      ]
+    },
+    "public.journal_entry_source": {
+      "name": "journal_entry_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "invoice",
+        "adjustment",
+        "pos"
+      ]
+    },
+    "public.journal_entry_status": {
+      "name": "journal_entry_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.order_source_type": {
+      "name": "order_source_type",
+      "schema": "public",
+      "values": [
+        "INVENTORY",
+        "ON_DEMAND"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "CONFIRMED",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.pos_cash_movement_type": {
+      "name": "pos_cash_movement_type",
+      "schema": "public",
+      "values": [
+        "sale",
+        "refund",
+        "withdrawal",
+        "deposit"
+      ]
+    },
+    "public.pos_payment_method": {
+      "name": "pos_payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "card",
+        "check"
+      ]
+    },
+    "public.pos_sale_status": {
+      "name": "pos_sale_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "voided",
+        "refunded"
+      ]
+    },
+    "public.pos_session_status": {
+      "name": "pos_session_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.product_category_color": {
+      "name": "product_category_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow",
+        "pink",
+        "indigo",
+        "gray"
+      ]
+    },
+    "public.quotation_status": {
+      "name": "quotation_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "SENT",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.service_color": {
+      "name": "service_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow"
+      ]
+    },
+    "public.stock_movement_type": {
+      "name": "stock_movement_type",
+      "schema": "public",
+      "values": [
+        "entry",
+        "exit",
+        "adjustment"
+      ]
+    },
+    "public.product_type": {
+      "name": "product_type",
+      "schema": "public",
+      "values": [
+        "STOCK",
+        "MADE_TO_ORDER",
+        "SERVICE"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "FCE",
+        "FAUCI",
+        "FPE",
+        "NC",
+        "DA",
+        "RCE",
+        "FCAM",
+        "NABN",
+        "OTRO"
+      ]
+    },
+    "public.invoice_line_type": {
+      "name": "invoice_line_type",
+      "schema": "public",
+      "values": [
+        "goods",
+        "services"
+      ]
+    },
+    "public.invoice_source": {
+      "name": "invoice_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sat"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "L",
+        "I",
+        "D"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,5932 @@
+{
+  "id": "cf6d5e0b-436a-42d3-91db-1b34eba23b26",
+  "prevId": "8fdb6778-1120-4d0a-a998-5b466a1aa1d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_account": {
+      "name": "accounting_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounting_account_organization_id_organization_id_fk": {
+          "name": "accounting_account_organization_id_organization_id_fk",
+          "tableFrom": "accounting_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_organization_id_organization_id_fk": {
+          "name": "appointment_organization_id_organization_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_client_id_business_partner_id_fk": {
+          "name": "appointment_client_id_business_partner_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_service_id_service_id_fk": {
+          "name": "appointment_service_id_service_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "service",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_staff_id_member_id_fk": {
+          "name": "appointment_staff_id_member_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "member",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_permissions": {
+          "name": "custom_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_role": {
+      "name": "invitation_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_role_invitation_id_invitation_id_fk": {
+          "name": "invitation_role_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_role_role_id_role_id_fk": {
+          "name": "invitation_role_role_id_role_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_role_unique": {
+          "name": "invitation_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_role_member_id_member_id_fk": {
+          "name": "member_role_member_id_member_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_role_role_id_role_id_fk": {
+          "name": "member_role_role_id_role_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_role_unique": {
+          "name": "member_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_domain_unique": {
+          "name": "organization_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission": {
+      "name": "permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_resource_action_idx": {
+          "name": "uq_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_organization_id_organization_id_fk": {
+          "name": "role_organization_id_organization_id_fk",
+          "tableFrom": "role",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission": {
+      "name": "role_permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permission_role_id_role_id_fk": {
+          "name": "role_permission_role_id_role_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_permission_id_permission_id_fk": {
+          "name": "role_permission_permission_id_permission_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "permission",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_organization_id_organization_id_fk": {
+          "name": "role_permission_organization_id_organization_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_partner": {
+      "name": "business_partner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_partner_email_org_idx": {
+          "name": "business_partner_email_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_partner_nit_org_idx": {
+          "name": "business_partner_nit_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_partner_organization_id_organization_id_fk": {
+          "name": "business_partner_organization_id_organization_id_fk",
+          "tableFrom": "business_partner",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_code_org_idx": {
+          "name": "company_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_organization_id_organization_id_fk": {
+          "name": "company_organization_id_organization_id_fk",
+          "tableFrom": "company",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "product_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STOCK'"
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_sku_org_idx": {
+          "name": "product_sku_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_org_type_idx": {
+          "name": "product_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_organization_id_organization_id_fk": {
+          "name": "product_organization_id_organization_id_fk",
+          "tableFrom": "product",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_category_id_product_category_id_fk": {
+          "name": "product_category_id_product_category_id_fk",
+          "tableFrom": "product",
+          "tableTo": "product_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_category": {
+      "name": "product_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "product_category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_category_org_name_idx": {
+          "name": "product_category_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_category_organization_id_organization_id_fk": {
+          "name": "product_category_organization_id_organization_id_fk",
+          "tableFrom": "product_category",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sat_file": {
+      "name": "sat_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_type": {
+          "name": "invoice_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_type": {
+          "name": "dte_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_number": {
+          "name": "dte_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitter_nit": {
+          "name": "emitter_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emitter_name": {
+          "name": "emitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_nit": {
+          "name": "receptor_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_name": {
+          "name": "receptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportation": {
+          "name": "exportation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "certificator_nit": {
+          "name": "certificator_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificator_name": {
+          "name": "certificator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "money": {
+          "name": "money",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva": {
+          "name": "iva",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_voided": {
+          "name": "is_voided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "voided_date": {
+          "name": "voided_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "petroleum": {
+          "name": "petroleum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "hotel": {
+          "name": "hotel",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tickets": {
+          "name": "tickets",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "press_stamp": {
+          "name": "press_stamp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "firefighters": {
+          "name": "firefighters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "municipal_tax": {
+          "name": "municipal_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "alcoholic_tax": {
+          "name": "alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tobacco_tax": {
+          "name": "tobacco_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cement_tax": {
+          "name": "cement_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "no_alcoholic_tax": {
+          "name": "no_alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "port_tariff_tax": {
+          "name": "port_tariff_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sat_file_unique_dte_idx": {
+          "name": "sat_file_unique_dte_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authorization_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serie",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sat_file_organization_id_organization_id_fk": {
+          "name": "sat_file_organization_id_organization_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_company_id_company_id_fk": {
+          "name": "sat_file_company_id_company_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_business_partner_id_business_partner_id_fk": {
+          "name": "sat_file_business_partner_id_business_partner_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_accounting_account_id_accounting_account_id_fk": {
+          "name": "sat_file_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line": {
+      "name": "invoice_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "invoice_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'goods'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_product_id_product_id_fk": {
+          "name": "invoice_line_product_id_product_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_file_id": {
+          "name": "sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "invoice_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'FCE'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'L'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_organization_id_organization_id_fk": {
+          "name": "invoice_organization_id_organization_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_company_id_company_id_fk": {
+          "name": "invoice_company_id_company_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_business_partner_id_business_partner_id_fk": {
+          "name": "invoice_business_partner_id_business_partner_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_accounting_account_id_accounting_account_id_fk": {
+          "name": "invoice_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_sat_file_id_sat_file_id_fk": {
+          "name": "invoice_sat_file_id_sat_file_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_line": {
+      "name": "journal_entry_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_amount": {
+          "name": "debit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "invoice_line_id": {
+          "name": "invoice_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_line_journal_entry_id_journal_entry_id_fk": {
+          "name": "journal_entry_line_journal_entry_id_journal_entry_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "journal_entry",
+          "columnsFrom": [
+            "journal_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_accounting_account_id_accounting_account_id_fk": {
+          "name": "journal_entry_line_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_invoice_line_id_invoice_line_id_fk": {
+          "name": "journal_entry_line_invoice_line_id_invoice_line_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "invoice_line",
+          "columnsFrom": [
+            "invoice_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry": {
+      "name": "journal_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_number": {
+          "name": "entry_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "journal_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_invoice_id": {
+          "name": "source_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sat_file_id": {
+          "name": "source_sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_pos_session_id": {
+          "name": "source_pos_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_debit": {
+          "name": "total_debit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_credit": {
+          "name": "total_credit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "journal_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_organization_id_organization_id_fk": {
+          "name": "journal_entry_organization_id_organization_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_company_id_company_id_fk": {
+          "name": "journal_entry_company_id_company_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_invoice_id_invoice_id_fk": {
+          "name": "journal_entry_source_invoice_id_invoice_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "source_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_sat_file_id_sat_file_id_fk": {
+          "name": "journal_entry_source_sat_file_id_sat_file_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "source_sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_posted_by_user_id_fk": {
+          "name": "journal_entry_posted_by_user_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "posted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_accounting_config": {
+      "name": "organization_accounting_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_credito_fiscal_account_id": {
+          "name": "iva_credito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iva_debito_fiscal_account_id": {
+          "name": "iva_debito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_receivable_account_id": {
+          "name": "accounts_receivable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_payable_account_id": {
+          "name": "accounts_payable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sales_account_id": {
+          "name": "default_sales_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_purchase_account_id": {
+          "name": "default_purchase_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_prefix": {
+          "name": "journal_entry_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JE'"
+        },
+        "next_journal_entry_number": {
+          "name": "next_journal_entry_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "manual_invoice_prefix": {
+          "name": "manual_invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "next_manual_invoice_number": {
+          "name": "next_manual_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "order_prefix": {
+          "name": "order_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OR'"
+        },
+        "next_order_number": {
+          "name": "next_order_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_prefix": {
+          "name": "pos_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POS'"
+        },
+        "next_pos_sale_number": {
+          "name": "next_pos_sale_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_cash_account_id": {
+          "name": "pos_cash_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_card_account_id": {
+          "name": "pos_card_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_check_account_id": {
+          "name": "pos_check_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_accounting_config_organization_id_organization_id_fk": {
+          "name": "organization_accounting_config_organization_id_organization_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_credito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_debito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_receivable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_payable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_sales_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_sales_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_sales_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_purchase_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_card_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_card_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_card_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_check_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_check_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_check_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_accounting_config_organization_id_unique": {
+          "name": "organization_accounting_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service": {
+      "name": "service",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "service_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "service_organization_id_organization_id_fk": {
+          "name": "service_organization_id_organization_id_fk",
+          "tableFrom": "service",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_movement": {
+      "name": "stock_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_date": {
+          "name": "movement_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stock_movement_organization_id_organization_id_fk": {
+          "name": "stock_movement_organization_id_organization_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_product_id_product_id_fk": {
+          "name": "stock_movement_product_id_product_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_created_by_id_user_id_fk": {
+          "name": "stock_movement_created_by_id_user_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_detail": {
+      "name": "order_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_detail_order_id_order_id_fk": {
+          "name": "order_detail_order_id_order_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_detail_product_id_product_id_fk": {
+          "name": "order_detail_product_id_product_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_organization_id_organization_id_fk": {
+          "name": "order_organization_id_organization_id_fk",
+          "tableFrom": "order",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_company_id_company_id_fk": {
+          "name": "order_company_id_company_id_fk",
+          "tableFrom": "order",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_business_partner_id_business_partner_id_fk": {
+          "name": "order_business_partner_id_business_partner_id_fk",
+          "tableFrom": "order",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_recipient": {
+      "name": "order_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_detail_id": {
+          "name": "order_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_recipient_order_detail_id_order_detail_id_fk": {
+          "name": "order_recipient_order_detail_id_order_detail_id_fk",
+          "tableFrom": "order_recipient",
+          "tableTo": "order_detail",
+          "columnsFrom": [
+            "order_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_detail": {
+      "name": "quotation_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_id": {
+          "name": "quotation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_detail_quotation_id_quotation_id_fk": {
+          "name": "quotation_detail_quotation_id_quotation_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "quotation",
+          "columnsFrom": [
+            "quotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_detail_product_id_product_id_fk": {
+          "name": "quotation_detail_product_id_product_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation": {
+      "name": "quotation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quotation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "quotation_date": {
+          "name": "quotation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotation_number": {
+          "name": "quotation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "converted_order_id": {
+          "name": "converted_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_organization_id_organization_id_fk": {
+          "name": "quotation_organization_id_organization_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_company_id_company_id_fk": {
+          "name": "quotation_company_id_company_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_business_partner_id_business_partner_id_fk": {
+          "name": "quotation_business_partner_id_business_partner_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_converted_order_id_order_id_fk": {
+          "name": "quotation_converted_order_id_order_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "order",
+          "columnsFrom": [
+            "converted_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_recipient": {
+      "name": "quotation_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_detail_id": {
+          "name": "quotation_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_recipient_quotation_detail_id_quotation_detail_id_fk": {
+          "name": "quotation_recipient_quotation_detail_id_quotation_detail_id_fk",
+          "tableFrom": "quotation_recipient",
+          "tableTo": "quotation_detail",
+          "columnsFrom": [
+            "quotation_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cash_movement": {
+      "name": "pos_cash_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pos_cash_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_cash_movement_session_id_pos_session_id_fk": {
+          "name": "pos_cash_movement_session_id_pos_session_id_fk",
+          "tableFrom": "pos_cash_movement",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cashier": {
+      "name": "pos_cashier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_attempts": {
+          "name": "pin_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pin_locked_at": {
+          "name": "pin_locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cashier_pin_org_idx": {
+          "name": "cashier_pin_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_cashier_organization_id_organization_id_fk": {
+          "name": "pos_cashier_organization_id_organization_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_cashier_user_id_user_id_fk": {
+          "name": "pos_cashier_user_id_user_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_payment": {
+      "name": "pos_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "pos_payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_amount": {
+          "name": "received_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_payment_sale_id_pos_sale_id_fk": {
+          "name": "pos_payment_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_payment",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale_line": {
+      "name": "pos_sale_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_percent": {
+          "name": "discount_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_sale_line_sale_id_pos_sale_id_fk": {
+          "name": "pos_sale_line_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pos_sale_line_product_id_product_id_fk": {
+          "name": "pos_sale_line_product_id_product_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale": {
+      "name": "pos_sale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sale_number": {
+          "name": "sale_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_sale_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_sale_idempotency_key_idx": {
+          "name": "pos_sale_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_terminal_created_idx": {
+          "name": "pos_sale_terminal_created_idx",
+          "columns": [
+            {
+              "expression": "terminal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_status_idx": {
+          "name": "pos_sale_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_org_created_idx": {
+          "name": "pos_sale_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_sale_organization_id_organization_id_fk": {
+          "name": "pos_sale_organization_id_organization_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_sucursal_id_sucursal_id_fk": {
+          "name": "pos_sale_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_sale_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_sale_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_business_partner_id_business_partner_id_fk": {
+          "name": "pos_sale_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_invoice_id_invoice_id_fk": {
+          "name": "pos_sale_invoice_id_invoice_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_session": {
+      "name": "pos_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_cash_amount": {
+          "name": "opening_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_cash_amount": {
+          "name": "closing_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash_amount": {
+          "name": "expected_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_session_organization_id_organization_id_fk": {
+          "name": "pos_session_organization_id_organization_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_sucursal_id_sucursal_id_fk": {
+          "name": "pos_session_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_session_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_session_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_terminal": {
+      "name": "pos_terminal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_generate_invoice": {
+          "name": "auto_generate_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_print_receipt": {
+          "name": "auto_print_receipt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_business_partner_id": {
+          "name": "default_business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_terminal_org_active_idx": {
+          "name": "pos_terminal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_terminal_organization_id_organization_id_fk": {
+          "name": "pos_terminal_organization_id_organization_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_sucursal_id_sucursal_id_fk": {
+          "name": "pos_terminal_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_default_business_partner_id_business_partner_id_fk": {
+          "name": "pos_terminal_default_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "default_business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_z_report": {
+      "name": "pos_z_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_name": {
+          "name": "terminal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_name": {
+          "name": "cashier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opening_cash": {
+          "name": "opening_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_cash": {
+          "name": "closing_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash": {
+          "name": "expected_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cash_difference": {
+          "name": "cash_difference",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sales": {
+          "name": "total_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cash_sales": {
+          "name": "total_cash_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_card_sales": {
+          "name": "total_card_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_check_sales": {
+          "name": "total_check_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_refunds": {
+          "name": "total_refunds",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_withdrawals": {
+          "name": "total_withdrawals",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deposits": {
+          "name": "total_deposits",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tax": {
+          "name": "total_tax",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_order_time": {
+          "name": "first_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_time": {
+          "name": "last_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_z_report_session_id_pos_session_id_fk": {
+          "name": "pos_z_report_session_id_pos_session_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_z_report_organization_id_organization_id_fk": {
+          "name": "pos_z_report_organization_id_organization_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pos_z_report_session_id_unique": {
+          "name": "pos_z_report_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_movement": {
+      "name": "inventory_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "inventory_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inventory_movement_org_idx": {
+          "name": "inventory_movement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_product_idx": {
+          "name": "inventory_movement_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_sucursal_idx": {
+          "name": "inventory_movement_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_movement_organization_id_organization_id_fk": {
+          "name": "inventory_movement_organization_id_organization_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_sucursal_id_sucursal_id_fk": {
+          "name": "inventory_movement_sucursal_id_sucursal_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_product_id_product_id_fk": {
+          "name": "inventory_movement_product_id_product_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal_inventory": {
+      "name": "sucursal_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_inventory_sucursal_product_idx": {
+          "name": "sucursal_inventory_sucursal_product_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_inventory_sucursal_idx": {
+          "name": "sucursal_inventory_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_inventory_sucursal_id_sucursal_id_fk": {
+          "name": "sucursal_inventory_sucursal_id_sucursal_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sucursal_inventory_product_id_product_id_fk": {
+          "name": "sucursal_inventory_product_id_product_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal": {
+      "name": "sucursal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_code_org_idx": {
+          "name": "sucursal_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_org_active_idx": {
+          "name": "sucursal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_organization_id_organization_id_fk": {
+          "name": "sucursal_organization_id_organization_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sucursal_company_id_company_id_fk": {
+          "name": "sucursal_company_id_company_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_module_access": {
+      "name": "member_module_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_module_access_member_id_member_id_fk": {
+          "name": "member_module_access_member_id_member_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_module_access_organization_id_organization_id_fk": {
+          "name": "member_module_access_organization_id_organization_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_module_unique": {
+          "name": "member_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_module": {
+      "name": "organization_module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_module_organization_id_organization_id_fk": {
+          "name": "organization_module_organization_id_organization_id_fk",
+          "tableFrom": "organization_module",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_module_unique": {
+          "name": "org_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "cancelled",
+        "completed"
+      ]
+    },
+    "public.inventory_movement_type": {
+      "name": "inventory_movement_type",
+      "schema": "public",
+      "values": [
+        "in",
+        "out",
+        "transfer_to_sucursal",
+        "transfer_from_sucursal",
+        "adjustment"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.invoice_type": {
+      "name": "invoice_type",
+      "schema": "public",
+      "values": [
+        "purchase",
+        "sale"
+      ]
+    },
+    "public.iva_type": {
+      "name": "iva_type",
+      "schema": "public",
+      "values": [
+        "taxed",
+        "exempt",
+        "non_subject"
+      ]
+    },
+    "public.journal_entry_source": {
+      "name": "journal_entry_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "invoice",
+        "adjustment",
+        "pos"
+      ]
+    },
+    "public.journal_entry_status": {
+      "name": "journal_entry_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.order_source_type": {
+      "name": "order_source_type",
+      "schema": "public",
+      "values": [
+        "INVENTORY",
+        "ON_DEMAND"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "CONFIRMED",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.pos_cash_movement_type": {
+      "name": "pos_cash_movement_type",
+      "schema": "public",
+      "values": [
+        "sale",
+        "refund",
+        "withdrawal",
+        "deposit"
+      ]
+    },
+    "public.pos_payment_method": {
+      "name": "pos_payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "card",
+        "check"
+      ]
+    },
+    "public.pos_sale_status": {
+      "name": "pos_sale_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "voided",
+        "refunded"
+      ]
+    },
+    "public.pos_session_status": {
+      "name": "pos_session_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.product_category_color": {
+      "name": "product_category_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow",
+        "pink",
+        "indigo",
+        "gray"
+      ]
+    },
+    "public.quotation_status": {
+      "name": "quotation_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "SENT",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.service_color": {
+      "name": "service_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow"
+      ]
+    },
+    "public.stock_movement_type": {
+      "name": "stock_movement_type",
+      "schema": "public",
+      "values": [
+        "entry",
+        "exit",
+        "adjustment"
+      ]
+    },
+    "public.product_type": {
+      "name": "product_type",
+      "schema": "public",
+      "values": [
+        "STOCK",
+        "MADE_TO_ORDER",
+        "SERVICE"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "FCE",
+        "FAUCI",
+        "FPE",
+        "NC",
+        "DA",
+        "RCE",
+        "FCAM",
+        "NABN",
+        "OTRO"
+      ]
+    },
+    "public.invoice_line_type": {
+      "name": "invoice_line_type",
+      "schema": "public",
+      "values": [
+        "goods",
+        "services"
+      ]
+    },
+    "public.invoice_source": {
+      "name": "invoice_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sat"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "L",
+        "I",
+        "D"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,5970 @@
+{
+  "id": "e466d0fc-9264-4a44-ac85-8f3043f0ab7f",
+  "prevId": "cf6d5e0b-436a-42d3-91db-1b34eba23b26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_account": {
+      "name": "accounting_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounting_account_organization_id_organization_id_fk": {
+          "name": "accounting_account_organization_id_organization_id_fk",
+          "tableFrom": "accounting_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_organization_id_organization_id_fk": {
+          "name": "appointment_organization_id_organization_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_client_id_business_partner_id_fk": {
+          "name": "appointment_client_id_business_partner_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_service_id_service_id_fk": {
+          "name": "appointment_service_id_service_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "service",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_staff_id_member_id_fk": {
+          "name": "appointment_staff_id_member_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "member",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_permissions": {
+          "name": "custom_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_role": {
+      "name": "invitation_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_role_invitation_id_invitation_id_fk": {
+          "name": "invitation_role_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_role_role_id_role_id_fk": {
+          "name": "invitation_role_role_id_role_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_role_unique": {
+          "name": "invitation_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_role_member_id_member_id_fk": {
+          "name": "member_role_member_id_member_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_role_role_id_role_id_fk": {
+          "name": "member_role_role_id_role_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_role_unique": {
+          "name": "member_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_domain_unique": {
+          "name": "organization_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission": {
+      "name": "permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_resource_action_idx": {
+          "name": "uq_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_organization_id_organization_id_fk": {
+          "name": "role_organization_id_organization_id_fk",
+          "tableFrom": "role",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission": {
+      "name": "role_permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permission_role_id_role_id_fk": {
+          "name": "role_permission_role_id_role_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_permission_id_permission_id_fk": {
+          "name": "role_permission_permission_id_permission_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "permission",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_organization_id_organization_id_fk": {
+          "name": "role_permission_organization_id_organization_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_partner": {
+      "name": "business_partner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_partner_email_org_idx": {
+          "name": "business_partner_email_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_partner_nit_org_idx": {
+          "name": "business_partner_nit_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_partner_organization_id_organization_id_fk": {
+          "name": "business_partner_organization_id_organization_id_fk",
+          "tableFrom": "business_partner",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_code_org_idx": {
+          "name": "company_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_organization_id_organization_id_fk": {
+          "name": "company_organization_id_organization_id_fk",
+          "tableFrom": "company",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "product_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STOCK'"
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_sku_org_idx": {
+          "name": "product_sku_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_org_type_idx": {
+          "name": "product_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_organization_id_organization_id_fk": {
+          "name": "product_organization_id_organization_id_fk",
+          "tableFrom": "product",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_category_id_product_category_id_fk": {
+          "name": "product_category_id_product_category_id_fk",
+          "tableFrom": "product",
+          "tableTo": "product_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_category": {
+      "name": "product_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "product_category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_category_org_name_idx": {
+          "name": "product_category_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_category_organization_id_organization_id_fk": {
+          "name": "product_category_organization_id_organization_id_fk",
+          "tableFrom": "product_category",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sat_file": {
+      "name": "sat_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_type": {
+          "name": "invoice_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_type": {
+          "name": "dte_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_number": {
+          "name": "dte_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitter_nit": {
+          "name": "emitter_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emitter_name": {
+          "name": "emitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_nit": {
+          "name": "receptor_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_name": {
+          "name": "receptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportation": {
+          "name": "exportation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "certificator_nit": {
+          "name": "certificator_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificator_name": {
+          "name": "certificator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "money": {
+          "name": "money",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva": {
+          "name": "iva",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_voided": {
+          "name": "is_voided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "voided_date": {
+          "name": "voided_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "petroleum": {
+          "name": "petroleum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "hotel": {
+          "name": "hotel",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tickets": {
+          "name": "tickets",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "press_stamp": {
+          "name": "press_stamp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "firefighters": {
+          "name": "firefighters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "municipal_tax": {
+          "name": "municipal_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "alcoholic_tax": {
+          "name": "alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tobacco_tax": {
+          "name": "tobacco_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cement_tax": {
+          "name": "cement_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "no_alcoholic_tax": {
+          "name": "no_alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "port_tariff_tax": {
+          "name": "port_tariff_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sat_file_unique_dte_idx": {
+          "name": "sat_file_unique_dte_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authorization_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serie",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sat_file_organization_id_organization_id_fk": {
+          "name": "sat_file_organization_id_organization_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_company_id_company_id_fk": {
+          "name": "sat_file_company_id_company_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_business_partner_id_business_partner_id_fk": {
+          "name": "sat_file_business_partner_id_business_partner_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_accounting_account_id_accounting_account_id_fk": {
+          "name": "sat_file_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line": {
+      "name": "invoice_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "invoice_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'goods'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_product_id_product_id_fk": {
+          "name": "invoice_line_product_id_product_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_file_id": {
+          "name": "sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "invoice_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'FCE'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'L'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_organization_id_organization_id_fk": {
+          "name": "invoice_organization_id_organization_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_company_id_company_id_fk": {
+          "name": "invoice_company_id_company_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_business_partner_id_business_partner_id_fk": {
+          "name": "invoice_business_partner_id_business_partner_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_accounting_account_id_accounting_account_id_fk": {
+          "name": "invoice_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_sat_file_id_sat_file_id_fk": {
+          "name": "invoice_sat_file_id_sat_file_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_line": {
+      "name": "journal_entry_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_amount": {
+          "name": "debit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "invoice_line_id": {
+          "name": "invoice_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_line_journal_entry_id_journal_entry_id_fk": {
+          "name": "journal_entry_line_journal_entry_id_journal_entry_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "journal_entry",
+          "columnsFrom": [
+            "journal_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_accounting_account_id_accounting_account_id_fk": {
+          "name": "journal_entry_line_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_invoice_line_id_invoice_line_id_fk": {
+          "name": "journal_entry_line_invoice_line_id_invoice_line_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "invoice_line",
+          "columnsFrom": [
+            "invoice_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry": {
+      "name": "journal_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_number": {
+          "name": "entry_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "journal_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_invoice_id": {
+          "name": "source_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sat_file_id": {
+          "name": "source_sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_pos_session_id": {
+          "name": "source_pos_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_debit": {
+          "name": "total_debit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_credit": {
+          "name": "total_credit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "journal_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_organization_id_organization_id_fk": {
+          "name": "journal_entry_organization_id_organization_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_company_id_company_id_fk": {
+          "name": "journal_entry_company_id_company_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_invoice_id_invoice_id_fk": {
+          "name": "journal_entry_source_invoice_id_invoice_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "source_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_sat_file_id_sat_file_id_fk": {
+          "name": "journal_entry_source_sat_file_id_sat_file_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "source_sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_posted_by_user_id_fk": {
+          "name": "journal_entry_posted_by_user_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "posted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_accounting_config": {
+      "name": "organization_accounting_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_credito_fiscal_account_id": {
+          "name": "iva_credito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iva_debito_fiscal_account_id": {
+          "name": "iva_debito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_receivable_account_id": {
+          "name": "accounts_receivable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_payable_account_id": {
+          "name": "accounts_payable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sales_account_id": {
+          "name": "default_sales_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_purchase_account_id": {
+          "name": "default_purchase_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_prefix": {
+          "name": "journal_entry_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JE'"
+        },
+        "next_journal_entry_number": {
+          "name": "next_journal_entry_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "manual_invoice_prefix": {
+          "name": "manual_invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "next_manual_invoice_number": {
+          "name": "next_manual_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "order_prefix": {
+          "name": "order_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OR'"
+        },
+        "next_order_number": {
+          "name": "next_order_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_prefix": {
+          "name": "pos_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POS'"
+        },
+        "next_pos_sale_number": {
+          "name": "next_pos_sale_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_cash_account_id": {
+          "name": "pos_cash_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_card_account_id": {
+          "name": "pos_card_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_check_account_id": {
+          "name": "pos_check_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_accounting_config_organization_id_organization_id_fk": {
+          "name": "organization_accounting_config_organization_id_organization_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_credito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_debito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_receivable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_payable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_sales_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_sales_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_sales_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_purchase_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_card_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_card_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_card_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_check_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_check_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_check_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_accounting_config_organization_id_unique": {
+          "name": "organization_accounting_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service": {
+      "name": "service",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "service_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "service_organization_id_organization_id_fk": {
+          "name": "service_organization_id_organization_id_fk",
+          "tableFrom": "service",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_movement": {
+      "name": "stock_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_date": {
+          "name": "movement_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stock_movement_organization_id_organization_id_fk": {
+          "name": "stock_movement_organization_id_organization_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_product_id_product_id_fk": {
+          "name": "stock_movement_product_id_product_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_created_by_id_user_id_fk": {
+          "name": "stock_movement_created_by_id_user_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_detail": {
+      "name": "order_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_detail_order_id_order_id_fk": {
+          "name": "order_detail_order_id_order_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_detail_product_id_product_id_fk": {
+          "name": "order_detail_product_id_product_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_organization_id_organization_id_fk": {
+          "name": "order_organization_id_organization_id_fk",
+          "tableFrom": "order",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_company_id_company_id_fk": {
+          "name": "order_company_id_company_id_fk",
+          "tableFrom": "order",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_business_partner_id_business_partner_id_fk": {
+          "name": "order_business_partner_id_business_partner_id_fk",
+          "tableFrom": "order",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_recipient": {
+      "name": "order_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_detail_id": {
+          "name": "order_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_recipient_order_detail_id_order_detail_id_fk": {
+          "name": "order_recipient_order_detail_id_order_detail_id_fk",
+          "tableFrom": "order_recipient",
+          "tableTo": "order_detail",
+          "columnsFrom": [
+            "order_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_detail": {
+      "name": "quotation_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_id": {
+          "name": "quotation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_detail_quotation_id_quotation_id_fk": {
+          "name": "quotation_detail_quotation_id_quotation_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "quotation",
+          "columnsFrom": [
+            "quotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_detail_product_id_product_id_fk": {
+          "name": "quotation_detail_product_id_product_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation": {
+      "name": "quotation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quotation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "quotation_date": {
+          "name": "quotation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotation_number": {
+          "name": "quotation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "converted_order_id": {
+          "name": "converted_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_organization_id_organization_id_fk": {
+          "name": "quotation_organization_id_organization_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_company_id_company_id_fk": {
+          "name": "quotation_company_id_company_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_business_partner_id_business_partner_id_fk": {
+          "name": "quotation_business_partner_id_business_partner_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_converted_order_id_order_id_fk": {
+          "name": "quotation_converted_order_id_order_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "order",
+          "columnsFrom": [
+            "converted_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_recipient": {
+      "name": "quotation_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_detail_id": {
+          "name": "quotation_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_recipient_quotation_detail_id_quotation_detail_id_fk": {
+          "name": "quotation_recipient_quotation_detail_id_quotation_detail_id_fk",
+          "tableFrom": "quotation_recipient",
+          "tableTo": "quotation_detail",
+          "columnsFrom": [
+            "quotation_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cash_movement": {
+      "name": "pos_cash_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pos_cash_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_cash_movement_session_id_pos_session_id_fk": {
+          "name": "pos_cash_movement_session_id_pos_session_id_fk",
+          "tableFrom": "pos_cash_movement",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cashier": {
+      "name": "pos_cashier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_attempts": {
+          "name": "pin_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pin_locked_at": {
+          "name": "pin_locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cashier_pin_org_idx": {
+          "name": "cashier_pin_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_cashier_organization_id_organization_id_fk": {
+          "name": "pos_cashier_organization_id_organization_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_cashier_user_id_user_id_fk": {
+          "name": "pos_cashier_user_id_user_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_payment": {
+      "name": "pos_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "pos_payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_amount": {
+          "name": "received_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_payment_sale_id_pos_sale_id_fk": {
+          "name": "pos_payment_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_payment",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale_line": {
+      "name": "pos_sale_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_percent": {
+          "name": "discount_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_sale_line_sale_id_pos_sale_id_fk": {
+          "name": "pos_sale_line_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pos_sale_line_product_id_product_id_fk": {
+          "name": "pos_sale_line_product_id_product_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale": {
+      "name": "pos_sale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sale_number": {
+          "name": "sale_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_sale_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_sale_idempotency_key_idx": {
+          "name": "pos_sale_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_terminal_created_idx": {
+          "name": "pos_sale_terminal_created_idx",
+          "columns": [
+            {
+              "expression": "terminal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_status_idx": {
+          "name": "pos_sale_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_org_created_idx": {
+          "name": "pos_sale_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_sale_organization_id_organization_id_fk": {
+          "name": "pos_sale_organization_id_organization_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_sucursal_id_sucursal_id_fk": {
+          "name": "pos_sale_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_sale_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_sale_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_business_partner_id_business_partner_id_fk": {
+          "name": "pos_sale_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_company_id_company_id_fk": {
+          "name": "pos_sale_company_id_company_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_invoice_id_invoice_id_fk": {
+          "name": "pos_sale_invoice_id_invoice_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_session": {
+      "name": "pos_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_cash_amount": {
+          "name": "opening_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_cash_amount": {
+          "name": "closing_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash_amount": {
+          "name": "expected_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_session_organization_id_organization_id_fk": {
+          "name": "pos_session_organization_id_organization_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_sucursal_id_sucursal_id_fk": {
+          "name": "pos_session_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_session_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_session_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_terminal": {
+      "name": "pos_terminal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_generate_invoice": {
+          "name": "auto_generate_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_print_receipt": {
+          "name": "auto_print_receipt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_business_partner_id": {
+          "name": "default_business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_terminal_org_active_idx": {
+          "name": "pos_terminal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_terminal_organization_id_organization_id_fk": {
+          "name": "pos_terminal_organization_id_organization_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_sucursal_id_sucursal_id_fk": {
+          "name": "pos_terminal_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_default_business_partner_id_business_partner_id_fk": {
+          "name": "pos_terminal_default_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "default_business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_company_id_company_id_fk": {
+          "name": "pos_terminal_company_id_company_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_z_report": {
+      "name": "pos_z_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_name": {
+          "name": "terminal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_name": {
+          "name": "cashier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opening_cash": {
+          "name": "opening_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_cash": {
+          "name": "closing_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash": {
+          "name": "expected_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cash_difference": {
+          "name": "cash_difference",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sales": {
+          "name": "total_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cash_sales": {
+          "name": "total_cash_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_card_sales": {
+          "name": "total_card_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_check_sales": {
+          "name": "total_check_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_refunds": {
+          "name": "total_refunds",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_withdrawals": {
+          "name": "total_withdrawals",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deposits": {
+          "name": "total_deposits",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tax": {
+          "name": "total_tax",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_order_time": {
+          "name": "first_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_time": {
+          "name": "last_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_z_report_session_id_pos_session_id_fk": {
+          "name": "pos_z_report_session_id_pos_session_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_z_report_organization_id_organization_id_fk": {
+          "name": "pos_z_report_organization_id_organization_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pos_z_report_session_id_unique": {
+          "name": "pos_z_report_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_movement": {
+      "name": "inventory_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "inventory_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inventory_movement_org_idx": {
+          "name": "inventory_movement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_product_idx": {
+          "name": "inventory_movement_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_sucursal_idx": {
+          "name": "inventory_movement_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_movement_organization_id_organization_id_fk": {
+          "name": "inventory_movement_organization_id_organization_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_sucursal_id_sucursal_id_fk": {
+          "name": "inventory_movement_sucursal_id_sucursal_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_product_id_product_id_fk": {
+          "name": "inventory_movement_product_id_product_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal_inventory": {
+      "name": "sucursal_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_inventory_sucursal_product_idx": {
+          "name": "sucursal_inventory_sucursal_product_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_inventory_sucursal_idx": {
+          "name": "sucursal_inventory_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_inventory_sucursal_id_sucursal_id_fk": {
+          "name": "sucursal_inventory_sucursal_id_sucursal_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sucursal_inventory_product_id_product_id_fk": {
+          "name": "sucursal_inventory_product_id_product_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal": {
+      "name": "sucursal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_code_org_idx": {
+          "name": "sucursal_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_org_active_idx": {
+          "name": "sucursal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_organization_id_organization_id_fk": {
+          "name": "sucursal_organization_id_organization_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sucursal_company_id_company_id_fk": {
+          "name": "sucursal_company_id_company_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_module_access": {
+      "name": "member_module_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_module_access_member_id_member_id_fk": {
+          "name": "member_module_access_member_id_member_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_module_access_organization_id_organization_id_fk": {
+          "name": "member_module_access_organization_id_organization_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_module_unique": {
+          "name": "member_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_module": {
+      "name": "organization_module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_module_organization_id_organization_id_fk": {
+          "name": "organization_module_organization_id_organization_id_fk",
+          "tableFrom": "organization_module",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_module_unique": {
+          "name": "org_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "cancelled",
+        "completed"
+      ]
+    },
+    "public.inventory_movement_type": {
+      "name": "inventory_movement_type",
+      "schema": "public",
+      "values": [
+        "in",
+        "out",
+        "transfer_to_sucursal",
+        "transfer_from_sucursal",
+        "adjustment"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.invoice_type": {
+      "name": "invoice_type",
+      "schema": "public",
+      "values": [
+        "purchase",
+        "sale"
+      ]
+    },
+    "public.iva_type": {
+      "name": "iva_type",
+      "schema": "public",
+      "values": [
+        "taxed",
+        "exempt",
+        "non_subject"
+      ]
+    },
+    "public.journal_entry_source": {
+      "name": "journal_entry_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "invoice",
+        "adjustment",
+        "pos"
+      ]
+    },
+    "public.journal_entry_status": {
+      "name": "journal_entry_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.order_source_type": {
+      "name": "order_source_type",
+      "schema": "public",
+      "values": [
+        "INVENTORY",
+        "ON_DEMAND"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "CONFIRMED",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.pos_cash_movement_type": {
+      "name": "pos_cash_movement_type",
+      "schema": "public",
+      "values": [
+        "sale",
+        "refund",
+        "withdrawal",
+        "deposit"
+      ]
+    },
+    "public.pos_payment_method": {
+      "name": "pos_payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "card",
+        "check"
+      ]
+    },
+    "public.pos_sale_status": {
+      "name": "pos_sale_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "voided",
+        "refunded"
+      ]
+    },
+    "public.pos_session_status": {
+      "name": "pos_session_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.product_category_color": {
+      "name": "product_category_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow",
+        "pink",
+        "indigo",
+        "gray"
+      ]
+    },
+    "public.quotation_status": {
+      "name": "quotation_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "SENT",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.service_color": {
+      "name": "service_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow"
+      ]
+    },
+    "public.stock_movement_type": {
+      "name": "stock_movement_type",
+      "schema": "public",
+      "values": [
+        "entry",
+        "exit",
+        "adjustment"
+      ]
+    },
+    "public.product_type": {
+      "name": "product_type",
+      "schema": "public",
+      "values": [
+        "STOCK",
+        "MADE_TO_ORDER",
+        "SERVICE"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "FCE",
+        "FAUCI",
+        "FPE",
+        "NC",
+        "DA",
+        "RCE",
+        "FCAM",
+        "NABN",
+        "OTRO"
+      ]
+    },
+    "public.invoice_line_type": {
+      "name": "invoice_line_type",
+      "schema": "public",
+      "values": [
+        "goods",
+        "services"
+      ]
+    },
+    "public.invoice_source": {
+      "name": "invoice_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sat"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "L",
+        "I",
+        "D"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,27 @@
       "when": 1772730816746,
       "tag": "0021_tough_revanche",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1772813462621,
+      "tag": "0022_charming_tyrannus",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1772818904998,
+      "tag": "0023_dizzy_wasp",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1772825761119,
+      "tag": "0024_rich_scarlet_spider",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-pos-products.sql
+++ b/scripts/seed-pos-products.sql
@@ -1,0 +1,407 @@
+-- =============================================================================
+-- POS Demo Data: Categorías y Productos para presentación
+-- =============================================================================
+-- IMPORTANTE: Reemplazá el valor de ORG_ID con el organization_id real.
+-- Para obtenerlo: SELECT id, name FROM organization LIMIT 5;
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_org_id UUID := 'f87b837e-73f7-43df-9e28-faa2d2a30979';  -- << CAMBIAR ESTO
+
+  -- Categoría IDs
+  cat_hamburguesas UUID;
+  cat_combos       UUID;
+  cat_gaseosas     UUID;
+  cat_snacks       UUID;
+  cat_postres      UUID;
+  cat_sandwiches   UUID;
+  cat_ropa         UUID;
+
+BEGIN
+
+  -- ===========================================================================
+  -- CATEGORÍAS
+  -- ===========================================================================
+
+  INSERT INTO product_category (id, organization_id, name, color, created_at, updated_at)
+  VALUES
+    (gen_random_uuid(), v_org_id, 'Hamburguesas', 'red',    NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Combos',       'orange', NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Gaseosas',     'blue',   NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Snacks',       'yellow', NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Postres',      'pink',   NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Sándwiches',   'green',  NOW(), NOW()),
+    (gen_random_uuid(), v_org_id, 'Ropa',         'purple', NOW(), NOW())
+  ON CONFLICT DO NOTHING;
+
+  -- Recuperar IDs recién insertados
+  SELECT id INTO cat_hamburguesas FROM product_category WHERE organization_id = v_org_id AND name = 'Hamburguesas';
+  SELECT id INTO cat_combos       FROM product_category WHERE organization_id = v_org_id AND name = 'Combos';
+  SELECT id INTO cat_gaseosas     FROM product_category WHERE organization_id = v_org_id AND name = 'Gaseosas';
+  SELECT id INTO cat_snacks       FROM product_category WHERE organization_id = v_org_id AND name = 'Snacks';
+  SELECT id INTO cat_postres      FROM product_category WHERE organization_id = v_org_id AND name = 'Postres';
+  SELECT id INTO cat_sandwiches   FROM product_category WHERE organization_id = v_org_id AND name = 'Sándwiches';
+  SELECT id INTO cat_ropa         FROM product_category WHERE organization_id = v_org_id AND name = 'Ropa';
+
+  -- ===========================================================================
+  -- PRODUCTOS: HAMBURGUESAS
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_hamburguesas, 'BURG-001', 'Hamburguesa Clásica',
+     'Pan brioche, carne 180g, lechuga, tomate, cebolla, pepinillos, ketchup y mostaza',
+     850.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1568901346375-23c9450c58cd?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_hamburguesas, 'BURG-002', 'Hamburguesa Doble',
+     'Doble medallón de carne 360g, queso cheddar doble, bacon, salsa especial',
+     1250.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1553979459-d2229ba7433b?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_hamburguesas, 'BURG-003', 'Hamburguesa BBQ Bacon',
+     'Carne 180g, bacon crocante, queso ahumado, cebolla caramelizada, salsa BBQ',
+     1100.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1594212699903-ec8a3eca50f5?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_hamburguesas, 'BURG-004', 'Hamburguesa Crispy Chicken',
+     'Pollo crocante rebozado, coleslaw, pickles, salsa honey mustard',
+     980.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1562802378-063ec186a863?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_hamburguesas, 'BURG-005', 'Hamburguesa Veggie',
+     'Medallón de lentejas y quinoa, aguacate, rúcula, tomate cherry, salsa de yogur',
+     900.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1520072959219-c595dc870360?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_hamburguesas, 'BURG-006', 'Hamburguesa Monster',
+     'Triple carne 540g, triple queso, bacon doble, huevo frito, jalapeños',
+     1650.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1561758033-d89a9ad46330?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: COMBOS
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_combos, 'COMBO-001', 'Combo Clásico',
+     'Hamburguesa Clásica + Papas medianas + Gaseosa 350ml',
+     1350.00, 999, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_combos, 'COMBO-002', 'Combo Doble Power',
+     'Hamburguesa Doble + Papas grandes + Gaseosa 500ml',
+     1800.00, 999, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1594212699903-ec8a3eca50f5?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_combos, 'COMBO-003', 'Combo BBQ',
+     'Hamburguesa BBQ Bacon + Aros de cebolla + Gaseosa 350ml',
+     1600.00, 999, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1550547660-d9450f859349?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_combos, 'COMBO-004', 'Combo Familiar x4',
+     '4 Hamburguesas Clásicas + 2 Papas grandes + 4 Gaseosas 350ml',
+     4500.00, 999, 2, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_combos, 'COMBO-005', 'Combo Kids',
+     'Hamburguesa mini + Papas chicas + Jugo de naranja 250ml',
+     850.00, 999, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1551782450-a2132b4ba21d?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: GASEOSAS
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_gaseosas, 'BEV-001', 'Coca-Cola 350ml',
+     'Lata de Coca-Cola 350ml bien fría',
+     450.00, 200, 20, 'STOCK',
+     'https://images.unsplash.com/photo-1554866585-cd94860890b7?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-002', 'Coca-Cola 500ml',
+     'Botella de Coca-Cola 500ml',
+     600.00, 150, 20, 'STOCK',
+     'https://images.unsplash.com/photo-1622483767028-3f66f32aef97?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-003', 'Sprite 350ml',
+     'Lata de Sprite 350ml',
+     450.00, 150, 20, 'STOCK',
+     'https://images.unsplash.com/photo-1527960471264-932f39eb5846?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-004', 'Fanta Naranja 350ml',
+     'Lata de Fanta naranja 350ml',
+     450.00, 150, 20, 'STOCK',
+     'https://images.unsplash.com/photo-1603569283847-aa295f0d016a?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-005', 'Agua Mineral 500ml',
+     'Agua mineral sin gas 500ml',
+     300.00, 200, 20, 'STOCK',
+     'https://images.unsplash.com/photo-1560023907-5f339617ea30?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-006', 'Agua con Gas 500ml',
+     'Agua mineral con gas 500ml',
+     320.00, 100, 10, 'STOCK',
+     'https://images.unsplash.com/photo-1571091718767-18b5b1457add?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-007', 'Jugo de Naranja Natural',
+     'Jugo de naranja exprimido al momento 300ml',
+     550.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1621506289937-a8e4df240d0b?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-008', 'Cerveza Artesanal Rubia',
+     'Cerveza artesanal rubia tipo lager 473ml',
+     750.00, 80, 10, 'STOCK',
+     'https://images.unsplash.com/photo-1518791841217-8f162f1912da?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_gaseosas, 'BEV-009', 'Limonada',
+     'Limonada casera con menta y hielo 400ml',
+     480.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1621263764928-df1444c5e859?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: SNACKS
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_snacks, 'SNK-001', 'Papas Fritas Chicas',
+     'Papas fritas crocantes porción chica',
+     380.00, 999, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1573080496219-bb080dd4f877?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-002', 'Papas Fritas Medianas',
+     'Papas fritas crocantes porción mediana',
+     480.00, 999, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1541592106381-b31e9677c0e5?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-003', 'Papas Fritas Grandes',
+     'Papas fritas crocantes porción grande',
+     580.00, 999, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1576777647209-e8733d7b851d?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-004', 'Aros de Cebolla',
+     'Aros de cebolla rebozados y fritos, porción 8 unidades',
+     520.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1639024471283-03518883512d?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-005', 'Nuggets de Pollo x6',
+     '6 nuggets de pollo crocantes con salsa a elección',
+     620.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1562967914-608f82629710?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-006', 'Nuggets de Pollo x12',
+     '12 nuggets de pollo crocantes con 2 salsas a elección',
+     1100.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1585325701956-60dd9c8553bc?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-007', 'Papas Rústicas',
+     'Papas cortadas en gajos con cáscara, condimentadas',
+     520.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1518013431117-eb1465fa5752?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-008', 'Alitas de Pollo x6',
+     '6 alitas de pollo BBQ o picantes',
+     750.00, 80, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1567620832903-9fc6debc209f?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_snacks, 'SNK-009', 'Mozzarella Sticks x4',
+     '4 bastones de mozzarella rebozados con salsa marinara',
+     650.00, 80, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1531749668029-2db88e4276c7?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: POSTRES
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_postres, 'DST-001', 'Helado Soft Vainilla',
+     'Cono de helado soft de vainilla',
+     380.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1501443762994-82bd5dace89a?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-002', 'Helado Soft Chocolate',
+     'Cono de helado soft de chocolate',
+     380.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1563805042-7684c019e1cb?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-003', 'Sundae Frutilla',
+     'Helado de vainilla con salsa de frutilla y crema',
+     520.00, 50, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1557142046-c704a3adf364?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-004', 'Brownie con Helado',
+     'Brownie de chocolate tibio con helado de vainilla y salsa de caramelo',
+     750.00, 30, 3, 'STOCK',
+     'https://images.unsplash.com/photo-1564355808539-22fda35bed7e?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-005', 'Milkshake Vainilla',
+     'Milkshake cremoso de vainilla 400ml',
+     680.00, 30, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1541658016709-82535e94bc69?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-006', 'Milkshake Chocolate',
+     'Milkshake cremoso de chocolate 400ml',
+     680.00, 30, 5, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1572490122747-3968b75cc699?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_postres, 'DST-007', 'Cheesecake de Maracuyá',
+     'Porción de cheesecake con coulis de maracuyá',
+     650.00, 20, 3, 'STOCK',
+     'https://images.unsplash.com/photo-1524351199678-941a58a3df50?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: SÁNDWICHES
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, created_at, updated_at)
+  VALUES
+    (v_org_id, cat_sandwiches, 'SND-001', 'Club Sándwich',
+     'Pan lactal tostado, pollo a la plancha, jamón, queso, lechuga, tomate, mayonesa',
+     780.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1528735602780-2552fd46c7af?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_sandwiches, 'SND-002', 'Sándwich Caprese',
+     'Ciabatta, mozzarella fresca, tomate cherry, albahaca, reducción de balsámico',
+     720.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1481070414801-51fd732d7184?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_sandwiches, 'SND-003', 'Sándwich de Milanesa',
+     'Pan árabe, milanesa de ternera, lechuga, tomate, mayonesa y limón',
+     850.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1603046891744-1f057007e9e7?w=200&h=200&fit=crop',
+     NOW(), NOW()),
+
+    (v_org_id, cat_sandwiches, 'SND-004', 'Wrap de Pollo',
+     'Tortilla de trigo, pollo a la plancha, mix de verdes, queso rallado, salsa ranch',
+     750.00, 100, 10, 'MADE_TO_ORDER',
+     'https://images.unsplash.com/photo-1626700051175-6818013e1d4f?w=200&h=200&fit=crop',
+     NOW(), NOW());
+
+  -- ===========================================================================
+  -- PRODUCTOS: ROPA (con custom attributes: Talla y Color)
+  -- ===========================================================================
+
+  INSERT INTO product (organization_id, category_id, sku, name, description, price, stock, min_stock, product_type, image_url, attributes_json, created_at, updated_at)
+  VALUES
+    (
+      v_org_id, cat_ropa, 'ROPA-001', 'Camiseta Premium',
+      'Camiseta 100% algodón peinado, corte slim fit, disponible en múltiples tallas y colores',
+      250.00, 999, 10, 'STOCK',
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=200&h=200&fit=crop',
+      '{
+        "attributes": [
+          {
+            "name": "Talla",
+            "key": "size",
+            "type": "button",
+            "values": [
+              { "label": "XS" },
+              { "label": "S" },
+              { "label": "M" },
+              { "label": "L" },
+              { "label": "XL", "priceAdjustment": 15 },
+              { "label": "2XL", "priceAdjustment": 25 },
+              { "label": "3XL", "priceAdjustment": 35 }
+            ]
+          },
+          {
+            "name": "Color",
+            "key": "color",
+            "type": "color",
+            "values": [
+              { "label": "Blanco", "hex": "#F5F5F5" },
+              { "label": "Negro", "hex": "#1a1a1a" },
+              { "label": "Rojo", "hex": "#EF4444", "priceAdjustment": 10 },
+              { "label": "Azul Marino", "hex": "#1E3A5F", "priceAdjustment": 10 },
+              { "label": "Verde", "hex": "#22C55E", "priceAdjustment": 10 }
+            ]
+          }
+        ]
+      }'::jsonb,
+      NOW(), NOW()
+    ),
+    (
+      v_org_id, cat_ropa, 'ROPA-002', 'Zapatilla Sport',
+      'Zapatilla deportiva con suela de goma y plantilla acolchada, ideal para uso diario',
+      850.00, 999, 5, 'STOCK',
+      'https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=200&h=200&fit=crop',
+      '{
+        "attributes": [
+          {
+            "name": "Talla (EU)",
+            "key": "size",
+            "type": "button",
+            "values": [
+              { "label": "35" },
+              { "label": "36" },
+              { "label": "37" },
+              { "label": "38" },
+              { "label": "39" },
+              { "label": "40" },
+              { "label": "41", "priceAdjustment": 50 },
+              { "label": "42", "priceAdjustment": 50 },
+              { "label": "43", "priceAdjustment": 50 }
+            ]
+          },
+          {
+            "name": "Color",
+            "key": "color",
+            "type": "color",
+            "values": [
+              { "label": "Blanco", "hex": "#F5F5F5" },
+              { "label": "Negro", "hex": "#1a1a1a" },
+              { "label": "Gris", "hex": "#6B7280", "priceAdjustment": 25 },
+              { "label": "Rojo", "hex": "#EF4444", "priceAdjustment": 50 }
+            ]
+          }
+        ]
+      }'::jsonb,
+      NOW(), NOW()
+    );
+
+  RAISE NOTICE '✅ Seed completado: % categorías y productos cargados para org %', 7, v_org_id;
+
+END $$;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,6 +25,9 @@
    * R2 Bucket for product image uploads
    * https://developers.cloudflare.com/r2/api/workers/workers-api-reference/
    */
+	"vars": {
+		"APP_DOMAIN": "bizops.app"
+	},
 	"r2_buckets": [
 		{
 			"binding": "BUCKET",


### PR DESCRIPTION
* Feat: POS, Company, and Organization Structure (#129)
* fix(db): guard inventory_movement_type enum creation against duplicates

Wrap CREATE TYPE in DO block with duplicate_object exception handler to prevent migration failure when enum already exists in production.

* fix(pos): redirect to pos-login on logout instead of login

* feat(pos): filter terminals by sucursal, add cross-sucursal stock visibility, and terminal edit dialog

- getTerminals() now accepts optional sucursalId to filter by branch (cashier POS session sees only their branch's terminals; ERP admin sees all)
- getProductsForPos() adds otherSucursalesStock subquery to show stock availability from other branches when current sucursal has 0 stock
- PosProductGrid displays cross-sucursal stock indicator in blue on out-of-stock cards, red color for zero stock
- Add edit terminal dialog in pos-settings/terminals with pre-populated fields (name, sucursal, default customer, toggles)

* fix(pos): add isActive toggle to terminal edit dialog

* feat(pos): add numeric keypad for direct quantity input in cart

Always-visible numpad below cart items allows typing quantities directly (e.g. 60) instead of clicking +/- repeatedly. Clicking a cart item or adding a product auto-selects it; numpad is disabled when no item is selected. Stock validation clamps input for STOCK-type products.

* feat(organization): add logo upload and domain field

Add logo image upload (stored as base64) and domain subdomain field to organization create/show flow. Domain is persisted via Drizzle after Better Auth creates the org. Includes migration for new domain column and APP_DOMAIN env var.

* feat(modules): add per-org module subscriptions and per-user access levels

- Add organization_module and member_module_access DB tables with migration
- Create ModulesRepository with org activation and member access CRUD
- Add /settings/modules route for super-admin org module management
- Add /users/:memberId/module-permissions route for per-user access config
- Extend AuthContext with moduleAccess field loaded in AppLayout
- Filter sidebar sections by moduleKey based on user module access
- Update home Modules component to show only accessible modules

* fix(organization): use optional chaining for cloudflare context in show loader

* feat(pos): link terminals and sales to company (legal entity)

Add optional companyId FK to pos_terminal and pos_sale tables. Terminal settings now include a company selector. Sales inherit companyId from terminal at checkout. Invoice auto-generation prefers terminal company over sucursal company fallback.

* feat(organization): add edit route, delete validations and super admin restrictions

- Add /:slug/edit route with full form (name, slug, logo, domain)
- Add update.action.ts with slug uniqueness check and logo base64 processing
- Restrict delete button visibility to super admins only
- Add delete validations: active modules, member count, companies, POS terminals
- Replace window.confirm with AlertDialog requiring org name to confirm deletion
- Add auth to show loader and display active modules as badges
- Remove debug data section from show page

* feat(pos): support product attributes in cart with cartItemId-based selection

- Add PosProductAttributesDialog for attribute selection before adding to cart
- Use cartItemId instead of productId as cart item key to allow duplicate products with different attributes
- Show selected attributes as subtitle in PosCartItem
- Propagate e.stopPropagation() on quantity/remove buttons to avoid item deselect
- Add seed SQL script for POS products with attributes