### PR TITLE
fix(migrations): guard ADD COLUMN and ADD CONSTRAINT in migration 0024

### DIFF
--- a/drizzle/0024_rich_scarlet_spider.sql
+++ b/drizzle/0024_rich_scarlet_spider.sql
@@ -1,4 +1,35 @@
-ALTER TABLE "pos_sale" ADD COLUMN "company_id" uuid;--> statement-breakpoint
-ALTER TABLE "pos_terminal" ADD COLUMN "company_id" uuid;--> statement-breakpoint
-ALTER TABLE "pos_sale" ADD CONSTRAINT "pos_sale_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "pos_terminal" ADD CONSTRAINT "pos_terminal_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'pos_sale' AND column_name = 'company_id'
+  ) THEN
+    ALTER TABLE "pos_sale" ADD COLUMN "company_id" uuid;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'pos_terminal' AND column_name = 'company_id'
+  ) THEN
+    ALTER TABLE "pos_terminal" ADD COLUMN "company_id" uuid;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'pos_sale_company_id_company_id_fk' AND table_name = 'pos_sale'
+  ) THEN
+    ALTER TABLE "pos_sale" ADD CONSTRAINT "pos_sale_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'pos_terminal_company_id_company_id_fk' AND table_name = 'pos_terminal'
+  ) THEN
+    ALTER TABLE "pos_terminal" ADD CONSTRAINT "pos_terminal_company_id_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."company"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;


### PR DESCRIPTION
Wrap the two ADD COLUMN company_id statements and their foreign key constraints in DO blocks with IF NOT EXISTS guards to prevent failure when the columns already exist in production.