### PR TITLE
Feat: module organization

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run lint && npm run test
+npm run typecheck && npm run lint && npm run test

--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -257,6 +257,12 @@ export const navigationItems = [
         icon: Users,
       },
       {
+        name: 'Tables',
+        nameKey: 'sidebar.items.posTables' as TranslationKey,
+        path: '/pos-settings/tables',
+        icon: Shapes,
+      },
+      {
         name: 'sucursal',
         nameKey: 'sidebar.items.sucursal' as TranslationKey,
         path: '/sucursal',

--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -245,6 +245,12 @@ export const navigationItems = [
         icon: Monitor,
       },
       {
+        name: 'Kitchen',
+        nameKey: 'sidebar.items.kitchen' as TranslationKey,
+        path: '/kitchen',
+        icon: Drumstick,
+      },
+      {
         name: 'Terminals',
         nameKey: 'sidebar.items.posTerminals' as TranslationKey,
         path: '/pos-settings/terminals',

--- a/app/features/kitchen/server/repository.test.ts
+++ b/app/features/kitchen/server/repository.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/server/db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn() },
+}))
+
+vi.mock('~/server/db/schemas/kitchen', () => ({
+  kitchenTicketModel: { id: 'id', sucursalId: 'sucursal_id', status: 'status', ticketNumber: 'ticket_number', saleId: 'sale_id', createdAt: 'created_at' },
+  kitchenTicketItemModel: { ticketId: 'ticket_id', id: 'id' },
+}))
+
+vi.mock('~/server/db/schemas/pos', () => ({
+  posSaleModel: { id: 'id', tableId: 'table_id', orderType: 'order_type' },
+  posTableModel: { id: 'id', number: 'number' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args) => args),
+  eq: vi.fn((col, val) => ({ col, val })),
+  inArray: vi.fn((col, vals) => ({ col, vals })),
+  sql: vi.fn((s) => s),
+  leftJoin: vi.fn(),
+}))
+
+import { db } from '~/server/db'
+import { KitchenRepository } from './repository'
+
+const mockDb = vi.mocked(db)
+
+// Chain that ends in orderBy (for the main tickets query with joins)
+const makeOrderByChain = (resolved: unknown) => {
+  const c = { from: vi.fn(), where: vi.fn(), orderBy: vi.fn(), leftJoin: vi.fn() }
+  c.from.mockReturnValue(c)
+  c.leftJoin.mockReturnValue(c)
+  c.where.mockReturnValue(c)
+  c.orderBy.mockResolvedValue(resolved)
+  return c
+}
+
+// Chain that ends in where (for the items query)
+const makeWhereChain = (resolved: unknown) => {
+  const c = { from: vi.fn(), where: vi.fn() }
+  c.from.mockReturnValue(c)
+  c.where.mockResolvedValue(resolved)
+  return c
+}
+
+describe('KitchenRepository.getOpenTickets', () => {
+  let repo: KitchenRepository
+
+  beforeEach(() => {
+    repo = new KitchenRepository()
+    vi.clearAllMocks()
+  })
+
+  test('returns empty array when no tickets', async () => {
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(makeOrderByChain([]))
+
+    const result = await repo.getOpenTickets('suc-1')
+
+    expect(result).toEqual([])
+  })
+
+  test('includes pending, in_progress and ready tickets', async () => {
+    const tickets = [
+      { id: 't1', status: 'pending', ticketNumber: 1, saleId: null, tableNumber: null, orderType: null, sucursalId: 'suc-1', organizationId: 'org-1', notes: null, createdAt: new Date() },
+      { id: 't2', status: 'in_progress', ticketNumber: 2, saleId: null, tableNumber: null, orderType: null, sucursalId: 'suc-1', organizationId: 'org-1', notes: null, createdAt: new Date() },
+      { id: 't3', status: 'ready', ticketNumber: 3, saleId: null, tableNumber: null, orderType: null, sucursalId: 'suc-1', organizationId: 'org-1', notes: null, createdAt: new Date() },
+    ]
+
+    let callCount = 0
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callCount++
+      return callCount === 1 ? makeOrderByChain(tickets) : makeWhereChain([])
+    })
+
+    const result = await repo.getOpenTickets('suc-1')
+
+    expect(result).toHaveLength(3)
+    expect(result.map((t) => t.status)).toEqual(['pending', 'in_progress', 'ready'])
+  })
+
+  test('maps table number from joined sale', async () => {
+    const tickets = [
+      { id: 't1', status: 'pending', ticketNumber: 1, saleId: 's1', tableNumber: '5', orderType: 'dine_in', sucursalId: 'suc-1', organizationId: 'org-1', notes: null, createdAt: new Date() },
+    ]
+
+    let callCount = 0
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callCount++
+      return callCount === 1 ? makeOrderByChain(tickets) : makeWhereChain([])
+    })
+
+    const result = await repo.getOpenTickets('suc-1')
+
+    expect(result[0].tableNumber).toBe('5')
+    expect(result[0].orderType).toBe('dine_in')
+  })
+})

--- a/app/features/kitchen/server/repository.ts
+++ b/app/features/kitchen/server/repository.ts
@@ -4,6 +4,7 @@ import {
   kitchenTicketModel,
   kitchenTicketItemModel,
 } from '~/server/db/schemas/kitchen'
+import { posSaleModel, posTableModel } from '~/server/db/schemas/pos'
 import type { CreateKitchenTicketInput } from '../schemas'
 
 export interface KitchenTicketWithItems {
@@ -15,6 +16,8 @@ export interface KitchenTicketWithItems {
   ticketNumber: number
   notes: string | null
   createdAt: Date | null
+  tableNumber: string | null
+  orderType: string | null
   items: Array<{
     id: string
     productId: string | null
@@ -26,7 +29,8 @@ export interface KitchenTicketWithItems {
   }>
 }
 
-export class KitchenRepository {
+export { KitchenRepository }
+class KitchenRepository {
   async getNextTicketNumber(sucursalId: string | null, organizationId: string): Promise<number> {
     // Get max ticket number for this sucursal today and increment
     const today = new Date()
@@ -86,27 +90,43 @@ export class KitchenRepository {
   }
 
   async getOpenTickets(sucursalId: string): Promise<KitchenTicketWithItems[]> {
-    const tickets = await db
-      .select()
+    // Join with sale + table to get table number and order type
+    const rows = await db
+      .select({
+        id: kitchenTicketModel.id,
+        organizationId: kitchenTicketModel.organizationId,
+        sucursalId: kitchenTicketModel.sucursalId,
+        saleId: kitchenTicketModel.saleId,
+        status: kitchenTicketModel.status,
+        ticketNumber: kitchenTicketModel.ticketNumber,
+        notes: kitchenTicketModel.notes,
+        createdAt: kitchenTicketModel.createdAt,
+        tableNumber: posTableModel.number,
+        orderType: posSaleModel.orderType,
+      })
       .from(kitchenTicketModel)
+      .leftJoin(posSaleModel, eq(kitchenTicketModel.saleId, posSaleModel.id))
+      .leftJoin(posTableModel, eq(posSaleModel.tableId, posTableModel.id))
       .where(
         and(
           eq(kitchenTicketModel.sucursalId, sucursalId),
-          inArray(kitchenTicketModel.status, ['pending', 'in_progress'])
+          inArray(kitchenTicketModel.status, ['pending', 'in_progress', 'ready'])
         )
       )
       .orderBy(kitchenTicketModel.ticketNumber)
 
-    if (tickets.length === 0) return []
+    if (rows.length === 0) return []
 
-    const ticketIds = tickets.map((t) => t.id)
+    const ticketIds = rows.map((t) => t.id)
     const items = await db
       .select()
       .from(kitchenTicketItemModel)
       .where(inArray(kitchenTicketItemModel.ticketId, ticketIds))
 
-    return tickets.map((ticket) => ({
+    return rows.map((ticket) => ({
       ...ticket,
+      tableNumber: ticket.tableNumber ?? null,
+      orderType: ticket.orderType ?? null,
       items: items
         .filter((i) => i.ticketId === ticket.id)
         .map((i) => ({

--- a/app/features/modules/server/repository.test.ts
+++ b/app/features/modules/server/repository.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/server/db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db/schemas/modules', () => ({
+  organizationModuleModel: { organizationId: 'organization_id', moduleKey: 'module_key', isActive: 'is_active' },
+  memberModuleAccessModel: { memberId: 'member_id', moduleKey: 'module_key', accessLevel: 'access_level', organizationId: 'organization_id' },
+}))
+
+vi.mock('~/server/db/schemas/auth', () => ({
+  memberModel: { id: 'id', organizationId: 'organization_id', userId: 'user_id' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args) => args),
+  eq: vi.fn((col, val) => ({ col, val })),
+}))
+
+import { db } from '~/server/db'
+import { ModulesRepository } from './repository'
+
+const mockDb = vi.mocked(db)
+
+const makeSelectChain = (resolvedValue: unknown) => {
+  const chain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  }
+  chain.from.mockReturnValue(chain)
+  chain.where.mockReturnValue(chain)
+  chain.limit.mockResolvedValue(resolvedValue)
+  // where also resolves directly for non-limited queries
+  chain.where.mockResolvedValue(resolvedValue)
+  return chain
+}
+
+describe('ModulesRepository.autoGrantMemberAccess', () => {
+  let repo: ModulesRepository
+
+  beforeEach(() => {
+    repo = new ModulesRepository()
+    vi.clearAllMocks()
+  })
+
+  test('grants user access to members who have none access', async () => {
+    const getMemberAccessLevelSpy = vi
+      .spyOn(repo, 'getMemberAccessLevel')
+      .mockResolvedValue('none')
+
+    const setMemberModuleAccessSpy = vi
+      .spyOn(repo, 'setMemberModuleAccess')
+      .mockResolvedValue(undefined)
+
+    // Mock db.select for getting org members
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }, { id: 'member-2' }])
+    )
+
+    await repo.autoGrantMemberAccess('org-1', 'pos')
+
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledTimes(2)
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledWith('member-1', 'org-1', 'pos', 'user')
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledWith('member-2', 'org-1', 'pos', 'user')
+    expect(getMemberAccessLevelSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not downgrade members who already have admin or user access', async () => {
+    vi.spyOn(repo, 'getMemberAccessLevel').mockResolvedValue('admin')
+
+    const setMemberModuleAccessSpy = vi
+      .spyOn(repo, 'setMemberModuleAccess')
+      .mockResolvedValue(undefined)
+
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }])
+    )
+
+    await repo.autoGrantMemberAccess('org-1', 'pos')
+
+    expect(setMemberModuleAccessSpy).not.toHaveBeenCalled()
+  })
+
+  test('does nothing if org has no members', async () => {
+    const setMemberModuleAccessSpy = vi
+      .spyOn(repo, 'setMemberModuleAccess')
+      .mockResolvedValue(undefined)
+
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([])
+    )
+
+    await repo.autoGrantMemberAccess('org-1', 'pos')
+
+    expect(setMemberModuleAccessSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('ModulesRepository.revokeAllMembersAccess', () => {
+  let repo: ModulesRepository
+
+  beforeEach(() => {
+    repo = new ModulesRepository()
+    vi.clearAllMocks()
+  })
+
+  test('sets access to none for all org members', async () => {
+    const setMemberModuleAccessSpy = vi
+      .spyOn(repo, 'setMemberModuleAccess')
+      .mockResolvedValue(undefined)
+
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }, { id: 'member-2' }])
+    )
+
+    await repo.revokeAllMembersAccess('org-1', 'pos')
+
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledTimes(2)
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledWith('member-1', 'org-1', 'pos', 'none')
+    expect(setMemberModuleAccessSpy).toHaveBeenCalledWith('member-2', 'org-1', 'pos', 'none')
+  })
+
+  test('does nothing if org has no members', async () => {
+    const setMemberModuleAccessSpy = vi
+      .spyOn(repo, 'setMemberModuleAccess')
+      .mockResolvedValue(undefined)
+
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([])
+    )
+
+    await repo.revokeAllMembersAccess('org-1', 'pos')
+
+    expect(setMemberModuleAccessSpy).not.toHaveBeenCalled()
+  })
+})

--- a/app/features/modules/server/repository.ts
+++ b/app/features/modules/server/repository.ts
@@ -4,9 +4,10 @@ import {
   memberModuleAccessModel,
   organizationModuleModel,
 } from '~/server/db/schemas/modules'
+import { memberModel } from '~/server/db/schemas/auth'
 import { APP_MODULES, type ModuleAccessLevel, type ModuleKey } from '../constants'
 
-class ModulesRepository {
+export class ModulesRepository {
   async getOrgModules(organizationId: string) {
     return db
       .select()
@@ -141,6 +142,40 @@ class ModulesRepository {
     for (const moduleKey of APP_MODULES) {
       const level = access[moduleKey] ?? 'none'
       await this.setMemberModuleAccess(memberId, organizationId, moduleKey, level)
+    }
+  }
+
+  /**
+   * Auto-grants 'user' access to all org members who currently have 'none'.
+   * Members with existing 'user' or 'admin' access are not downgraded.
+   * Called when an org module is activated.
+   */
+  async autoGrantMemberAccess(organizationId: string, moduleKey: ModuleKey) {
+    const members = await db
+      .select({ id: memberModel.id })
+      .from(memberModel)
+      .where(eq(memberModel.organizationId, organizationId))
+
+    for (const member of members) {
+      const currentLevel = await this.getMemberAccessLevel(member.id, moduleKey)
+      if (currentLevel === 'none') {
+        await this.setMemberModuleAccess(member.id, organizationId, moduleKey, 'user')
+      }
+    }
+  }
+
+  /**
+   * Revokes module access (sets to 'none') for all members of an org.
+   * Called when an org module is deactivated.
+   */
+  async revokeAllMembersAccess(organizationId: string, moduleKey: ModuleKey) {
+    const members = await db
+      .select({ id: memberModel.id })
+      .from(memberModel)
+      .where(eq(memberModel.organizationId, organizationId))
+
+    for (const member of members) {
+      await this.setMemberModuleAccess(member.id, organizationId, moduleKey, 'none')
     }
   }
 

--- a/app/features/pos/components/PosTableSelectionView.tsx
+++ b/app/features/pos/components/PosTableSelectionView.tsx
@@ -1,0 +1,93 @@
+import { ShoppingBag } from 'lucide-react'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { cn } from '~/lib/utils'
+import type { PosTable } from '~/server/db/schemas/pos'
+
+interface PosTableSelectionViewProps {
+  tables: PosTable[]
+  onSelectTable: (table: PosTable) => void
+  onTakeout: () => void
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  available: 'Disponible',
+  occupied: 'Ocupada',
+  reserved: 'Reservada',
+}
+
+export function PosTableSelectionView({
+  tables,
+  onSelectTable,
+  onTakeout,
+}: PosTableSelectionViewProps) {
+  const available = tables.filter((t) => t.status === 'available')
+  const occupied = tables.filter((t) => t.status === 'occupied')
+  const reserved = tables.filter((t) => t.status === 'reserved')
+
+  return (
+    <div className='flex flex-1 flex-col gap-6 overflow-auto p-6'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h2 className='text-xl font-bold'>Seleccionar mesa</h2>
+          <p className='text-muted-foreground text-sm'>
+            Elegí una mesa o continuá con para llevar
+          </p>
+        </div>
+        <Button size='lg' variant='outline' onClick={onTakeout}>
+          <ShoppingBag className='mr-2 size-4' />
+          Para llevar
+        </Button>
+      </div>
+
+      {tables.length === 0 && (
+        <div className='text-muted-foreground flex flex-1 items-center justify-center text-sm'>
+          No hay mesas configuradas. Podés vender para llevar o configurar mesas
+          en Ajustes → Mesas.
+        </div>
+      )}
+
+      {tables.length > 0 && (
+        <div className='grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6'>
+          {[...available, ...reserved, ...occupied].map((table) => {
+            const isAvailable = table.status === 'available'
+            const isOccupied = table.status === 'occupied'
+            return (
+              <button
+                key={table.id}
+                onClick={() => isAvailable && onSelectTable(table)}
+                disabled={!isAvailable}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-2 rounded-xl border-2 p-4 transition-all',
+                  isAvailable &&
+                    'hover:border-primary hover:bg-primary/5 cursor-pointer',
+                  isOccupied && 'cursor-not-allowed opacity-60',
+                  !isAvailable && !isOccupied && 'cursor-not-allowed opacity-50'
+                )}
+              >
+                <span className='text-2xl font-bold'>{table.number}</span>
+                {table.capacity && (
+                  <span className='text-muted-foreground text-xs'>
+                    {table.capacity} pers.
+                  </span>
+                )}
+                <Badge
+                  variant={
+                    isAvailable
+                      ? 'default'
+                      : isOccupied
+                        ? 'secondary'
+                        : 'outline'
+                  }
+                  className='text-xs'
+                >
+                  {STATUS_LABEL[table.status]}
+                </Badge>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/features/pos/schemas.ts
+++ b/app/features/pos/schemas.ts
@@ -6,7 +6,26 @@ import {
   posSaleLineModel,
   posPaymentModel,
   posCashierModel,
+  posTableModel,
 } from '~/server/db/schemas/pos'
+
+// Table (Mesa) schemas
+export const insertTableSchema = createInsertSchema(posTableModel)
+export const selectTableSchema = createSelectSchema(posTableModel)
+
+export const createTableSchema = insertTableSchema
+  .omit({ id: true, createdAt: true, updatedAt: true })
+  .extend({
+    number: z.string().min(1, 'El número de mesa es requerido'),
+    organizationId: z.string().uuid(),
+    sucursalId: z.string().uuid().optional().nullable(),
+    capacity: z.coerce.number().int().positive().optional().nullable(),
+  })
+
+export const updateTableSchema = createTableSchema.partial()
+
+export type CreateTableInput = z.infer<typeof createTableSchema>
+export type UpdateTableInput = z.infer<typeof updateTableSchema>
 
 // Terminal schemas
 export const insertTerminalSchema = createInsertSchema(posTerminalModel)

--- a/app/features/pos/schemas.ts
+++ b/app/features/pos/schemas.ts
@@ -105,6 +105,9 @@ export const checkoutSchema = z.object({
   businessPartnerId: z.string().uuid(),
   idempotencyKey: z.string().uuid(),
   sessionId: z.string().uuid().optional(),
+  tableId: z.string().uuid().optional().nullable(),
+  orderType: z.enum(['dine_in', 'takeout', 'delivery']).optional().default('takeout'),
+  coverCount: z.number().int().positive().optional().nullable(),
   lines: z.array(checkoutLineSchema).min(1, 'Cart cannot be empty'),
   payments: z
     .array(checkoutPaymentSchema)

--- a/app/features/pos/server/actions/close-table-order.action.test.ts
+++ b/app/features/pos/server/actions/close-table-order.action.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/features/pos/server/repository/tables.repository', () => ({
+  posTablesRepository: {
+    getActiveOrderForTable: vi.fn(),
+    updateTableStatus: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db', () => ({
+  db: { transaction: vi.fn() },
+}))
+
+vi.mock('~/server/db/schemas/pos', () => ({
+  posSaleModel: {},
+  posPaymentModel: {},
+}))
+
+import { posTablesRepository } from '~/features/pos/server/repository/tables.repository'
+import { closeTableOrderAction } from './close-table-order.action'
+
+const mockRepo = vi.mocked(posTablesRepository)
+
+const makeInput = (overrides = {}) => ({
+  tableId: 'table-1',
+  saleNumber: 'T001-000001',
+  payments: [{ method: 'cash' as const, amount: '150.00', receivedAmount: '200.00', changeAmount: '50.00' }],
+  subtotal: '133.93',
+  ivaAmount: '16.07',
+  total: '150.00',
+  ...overrides,
+})
+
+describe('closeTableOrderAction', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('throws if no open order on table', async () => {
+    mockRepo.getActiveOrderForTable.mockResolvedValue(null)
+
+    await expect(closeTableOrderAction(makeInput())).rejects.toThrow('No open order found for this table')
+  })
+
+  test('closes sale, inserts payment and marks table available', async () => {
+    const openSale = { id: 'sale-1', status: 'open', tableId: 'table-1' }
+    const closedSale = { ...openSale, status: 'completed' }
+
+    mockRepo.getActiveOrderForTable.mockResolvedValue(openSale)
+    mockRepo.updateTableStatus.mockResolvedValue({ id: 'table-1', status: 'available' })
+
+    const { db } = await import('~/server/db')
+    ;(db.transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([closedSale]) }) }) }),
+          insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue([]) }),
+        }
+        return fn(tx)
+      }
+    )
+
+    const result = await closeTableOrderAction(makeInput())
+
+    expect(result).toEqual(closedSale)
+    expect(mockRepo.updateTableStatus).toHaveBeenCalledWith('table-1', 'available')
+  })
+})

--- a/app/features/pos/server/actions/close-table-order.action.test.ts
+++ b/app/features/pos/server/actions/close-table-order.action.test.ts
@@ -35,7 +35,7 @@ describe('closeTableOrderAction', () => {
   beforeEach(() => vi.clearAllMocks())
 
   test('throws if no open order on table', async () => {
-    mockRepo.getActiveOrderForTable.mockResolvedValue(null)
+    mockRepo.getActiveOrderForTable.mockResolvedValue(null as never)
 
     await expect(closeTableOrderAction(makeInput())).rejects.toThrow('No open order found for this table')
   })
@@ -44,8 +44,8 @@ describe('closeTableOrderAction', () => {
     const openSale = { id: 'sale-1', status: 'open', tableId: 'table-1' }
     const closedSale = { ...openSale, status: 'completed' }
 
-    mockRepo.getActiveOrderForTable.mockResolvedValue(openSale)
-    mockRepo.updateTableStatus.mockResolvedValue({ id: 'table-1', status: 'available' })
+    mockRepo.getActiveOrderForTable.mockResolvedValue(openSale as never)
+    mockRepo.updateTableStatus.mockResolvedValue({ id: 'table-1', status: 'available' } as never)
 
     const { db } = await import('~/server/db')
     ;(db.transaction as ReturnType<typeof vi.fn>).mockImplementation(

--- a/app/features/pos/server/actions/close-table-order.action.ts
+++ b/app/features/pos/server/actions/close-table-order.action.ts
@@ -1,0 +1,64 @@
+import { eq } from 'drizzle-orm'
+import { db } from '~/server/db'
+import { posSaleModel, posPaymentModel } from '~/server/db/schemas/pos'
+import { posTablesRepository } from '~/features/pos/server/repository/tables.repository'
+import type { PosPaymentMethod } from '~/server/db/schemas/pos'
+
+export interface CloseTablePayment {
+  method: PosPaymentMethod
+  amount: string
+  receivedAmount?: string
+  changeAmount?: string
+  exchangeRate?: string
+  reference?: string
+}
+
+export interface CloseTableOrderInput {
+  tableId: string
+  saleNumber: string
+  payments: CloseTablePayment[]
+  subtotal: string
+  ivaAmount: string
+  discountAmount?: string
+  total: string
+  notes?: string
+}
+
+export async function closeTableOrderAction(input: CloseTableOrderInput) {
+  const openSale = await posTablesRepository.getActiveOrderForTable(input.tableId)
+  if (!openSale) throw new Error('No open order found for this table')
+
+  const sale = await db.transaction(async (tx) => {
+    const [closedSale] = await tx
+      .update(posSaleModel)
+      .set({
+        status: 'completed',
+        saleNumber: input.saleNumber,
+        subtotal: input.subtotal,
+        ivaAmount: input.ivaAmount,
+        discountAmount: input.discountAmount ?? '0',
+        total: input.total,
+        notes: input.notes,
+      })
+      .where(eq(posSaleModel.id, openSale.id))
+      .returning()
+
+    await tx.insert(posPaymentModel).values(
+      input.payments.map((p) => ({
+        saleId: openSale.id,
+        method: p.method,
+        amount: p.amount,
+        receivedAmount: p.receivedAmount,
+        changeAmount: p.changeAmount,
+        exchangeRate: p.exchangeRate,
+        reference: p.reference,
+      }))
+    )
+
+    return closedSale
+  })
+
+  await posTablesRepository.updateTableStatus(input.tableId, 'available')
+
+  return sale
+}

--- a/app/features/pos/server/actions/create-sale.action.ts
+++ b/app/features/pos/server/actions/create-sale.action.ts
@@ -238,6 +238,9 @@ export async function createSaleAction(input: CheckoutInput) {
         terminalId: input.terminalId,
         cashierId: input.cashierId,
         sessionId: input.sessionId,
+        tableId: input.tableId ?? null,
+        orderType: input.orderType ?? 'takeout',
+        coverCount: input.coverCount ?? null,
         businessPartnerId: input.businessPartnerId,
         saleNumber,
         idempotencyKey: input.idempotencyKey,
@@ -390,6 +393,14 @@ export async function createSaleAction(input: CheckoutInput) {
         items: kitchenItems,
       })
     }
+  }
+
+  // 11. Release table if this was a dine-in order
+  if (input.tableId) {
+    const { posTablesRepository } = await import(
+      '~/features/pos/server/repository/tables.repository'
+    )
+    await posTablesRepository.updateTableStatus(input.tableId, 'available')
   }
 
   return { saleId: result.saleId, saleNumber: result.saleNumber }

--- a/app/features/pos/server/actions/open-table-order.action.test.ts
+++ b/app/features/pos/server/actions/open-table-order.action.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/features/pos/server/repository/tables.repository', () => ({
+  posTablesRepository: {
+    getTableById: vi.fn(),
+    getActiveOrderForTable: vi.fn(),
+    updateTableStatus: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db', () => ({
+  db: {
+    insert: vi.fn(),
+    transaction: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db/schemas/pos', () => ({
+  posSaleModel: {},
+}))
+
+import { posTablesRepository } from '~/features/pos/server/repository/tables.repository'
+import { openTableOrderAction } from './open-table-order.action'
+
+const mockRepo = vi.mocked(posTablesRepository)
+
+const makeInput = (overrides = {}) => ({
+  tableId: 'table-1',
+  organizationId: 'org-1',
+  sucursalId: 'suc-1',
+  terminalId: 'term-1',
+  cashierId: 'cashier-1',
+  sessionId: 'session-1',
+  businessPartnerId: 'bp-1',
+  coverCount: 2,
+  ...overrides,
+})
+
+describe('openTableOrderAction', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('throws if table not found', async () => {
+    mockRepo.getTableById.mockResolvedValue(null)
+
+    await expect(openTableOrderAction(makeInput())).rejects.toThrow('Table not found')
+  })
+
+  test('throws if table already has an open order', async () => {
+    mockRepo.getTableById.mockResolvedValue({ id: 'table-1', status: 'available' })
+    mockRepo.getActiveOrderForTable.mockResolvedValue({ id: 'sale-existing', status: 'open' })
+
+    await expect(openTableOrderAction(makeInput())).rejects.toThrow('Table already has an open order')
+  })
+
+  test('creates open sale and marks table as occupied', async () => {
+    const table = { id: 'table-1', number: '1', status: 'available' }
+    const newSale = { id: 'sale-1', status: 'open', tableId: 'table-1' }
+
+    mockRepo.getTableById.mockResolvedValue(table)
+    mockRepo.getActiveOrderForTable.mockResolvedValue(null)
+    mockRepo.updateTableStatus.mockResolvedValue({ ...table, status: 'occupied' })
+
+    const { db } = await import('~/server/db')
+    ;(db.transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => fn({ insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([newSale]) }) }) })
+    )
+
+    const result = await openTableOrderAction(makeInput())
+
+    expect(result).toEqual(newSale)
+    expect(mockRepo.updateTableStatus).toHaveBeenCalledWith('table-1', 'occupied')
+  })
+})

--- a/app/features/pos/server/actions/open-table-order.action.test.ts
+++ b/app/features/pos/server/actions/open-table-order.action.test.ts
@@ -40,14 +40,14 @@ describe('openTableOrderAction', () => {
   beforeEach(() => vi.clearAllMocks())
 
   test('throws if table not found', async () => {
-    mockRepo.getTableById.mockResolvedValue(null)
+    mockRepo.getTableById.mockResolvedValue(null as never)
 
     await expect(openTableOrderAction(makeInput())).rejects.toThrow('Table not found')
   })
 
   test('throws if table already has an open order', async () => {
-    mockRepo.getTableById.mockResolvedValue({ id: 'table-1', status: 'available' })
-    mockRepo.getActiveOrderForTable.mockResolvedValue({ id: 'sale-existing', status: 'open' })
+    mockRepo.getTableById.mockResolvedValue({ id: 'table-1', status: 'available' } as never)
+    mockRepo.getActiveOrderForTable.mockResolvedValue({ id: 'sale-existing', status: 'open' } as never)
 
     await expect(openTableOrderAction(makeInput())).rejects.toThrow('Table already has an open order')
   })
@@ -56,9 +56,9 @@ describe('openTableOrderAction', () => {
     const table = { id: 'table-1', number: '1', status: 'available' }
     const newSale = { id: 'sale-1', status: 'open', tableId: 'table-1' }
 
-    mockRepo.getTableById.mockResolvedValue(table)
-    mockRepo.getActiveOrderForTable.mockResolvedValue(null)
-    mockRepo.updateTableStatus.mockResolvedValue({ ...table, status: 'occupied' })
+    mockRepo.getTableById.mockResolvedValue(table as never)
+    mockRepo.getActiveOrderForTable.mockResolvedValue(null as never)
+    mockRepo.updateTableStatus.mockResolvedValue({ ...table, status: 'occupied' } as never)
 
     const { db } = await import('~/server/db')
     ;(db.transaction as ReturnType<typeof vi.fn>).mockImplementation(

--- a/app/features/pos/server/actions/open-table-order.action.ts
+++ b/app/features/pos/server/actions/open-table-order.action.ts
@@ -1,0 +1,48 @@
+import { db } from '~/server/db'
+import { posSaleModel } from '~/server/db/schemas/pos'
+import { posTablesRepository } from '~/features/pos/server/repository/tables.repository'
+
+export interface OpenTableOrderInput {
+  tableId: string
+  organizationId: string
+  sucursalId: string
+  terminalId: string
+  cashierId: string
+  sessionId: string
+  businessPartnerId: string
+  coverCount?: number
+}
+
+export async function openTableOrderAction(input: OpenTableOrderInput) {
+  const table = await posTablesRepository.getTableById(input.tableId)
+  if (!table) throw new Error('Table not found')
+
+  const existing = await posTablesRepository.getActiveOrderForTable(input.tableId)
+  if (existing) throw new Error('Table already has an open order')
+
+  const sale = await db.transaction(async (tx) => {
+    const [newSale] = await tx
+      .insert(posSaleModel)
+      .values({
+        organizationId: input.organizationId,
+        sucursalId: input.sucursalId,
+        terminalId: input.terminalId,
+        cashierId: input.cashierId,
+        sessionId: input.sessionId,
+        tableId: input.tableId,
+        businessPartnerId: input.businessPartnerId,
+        orderType: 'dine_in',
+        coverCount: input.coverCount,
+        status: 'open',
+        saleNumber: '',   // will be assigned on checkout
+        subtotal: '0',
+        total: '0',
+      })
+      .returning()
+    return newSale
+  })
+
+  await posTablesRepository.updateTableStatus(input.tableId, 'occupied')
+
+  return sale
+}

--- a/app/features/pos/server/repository/tables.repository.test.ts
+++ b/app/features/pos/server/repository/tables.repository.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/server/db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}))
+
+vi.mock('~/server/db/schemas/pos', () => ({
+  posTableModel: {
+    id: 'id',
+    organizationId: 'organization_id',
+    sucursalId: 'sucursal_id',
+    status: 'status',
+    isActive: 'is_active',
+  },
+  posSaleModel: {
+    tableId: 'table_id',
+    status: 'status',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args) => args),
+  eq: vi.fn((col, val) => ({ col, val })),
+  desc: vi.fn((col) => col),
+}))
+
+import { db } from '~/server/db'
+import { PosTablesRepository } from './tables.repository'
+
+const mockDb = vi.mocked(db)
+
+const makeSelectChain = (resolved: unknown) => {
+  const c = { from: vi.fn(), where: vi.fn(), orderBy: vi.fn(), limit: vi.fn() }
+  c.from.mockReturnValue(c)
+  c.orderBy.mockReturnValue(c)
+  c.limit.mockResolvedValue(resolved)
+  c.where.mockResolvedValue(resolved)
+  return c
+}
+
+const makeMutationChain = (resolved: unknown) => {
+  const c = { set: vi.fn(), values: vi.fn(), where: vi.fn(), returning: vi.fn() }
+  c.set.mockReturnValue(c)
+  c.values.mockReturnValue(c)
+  c.where.mockReturnValue(c)
+  c.returning.mockResolvedValue(resolved)
+  return c
+}
+
+describe('PosTablesRepository', () => {
+  let repo: PosTablesRepository
+
+  beforeEach(() => {
+    repo = new PosTablesRepository()
+    vi.clearAllMocks()
+  })
+
+  describe('getTables', () => {
+    test('returns all active tables for an org', async () => {
+      const tables = [{ id: 't1', number: '1', status: 'available' }]
+      ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(makeSelectChain(tables))
+
+      const result = await repo.getTables('org-1')
+
+      expect(result).toEqual(tables)
+    })
+  })
+
+  describe('createTable', () => {
+    test('inserts and returns new table', async () => {
+      const table = { id: 't1', number: '1', organizationId: 'org-1' }
+      ;(mockDb.insert as ReturnType<typeof vi.fn>).mockReturnValue(makeMutationChain([table]))
+
+      const result = await repo.createTable({ organizationId: 'org-1', number: '1' })
+
+      expect(result).toEqual(table)
+    })
+  })
+
+  describe('updateTableStatus', () => {
+    test('updates status of a table', async () => {
+      const updated = { id: 't1', status: 'occupied' }
+      ;(mockDb.update as ReturnType<typeof vi.fn>).mockReturnValue(makeMutationChain([updated]))
+
+      const result = await repo.updateTableStatus('t1', 'occupied')
+
+      expect(result).toEqual(updated)
+    })
+  })
+
+  describe('getActiveOrderForTable', () => {
+    test('returns the open sale for a table', async () => {
+      const sale = { id: 's1', tableId: 't1', status: 'open' }
+      ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(makeSelectChain([sale]))
+
+      const result = await repo.getActiveOrderForTable('t1')
+
+      expect(result).toEqual(sale)
+    })
+
+    test('returns null if no open sale', async () => {
+      ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(makeSelectChain([]))
+
+      const result = await repo.getActiveOrderForTable('t1')
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/app/features/pos/server/repository/tables.repository.ts
+++ b/app/features/pos/server/repository/tables.repository.ts
@@ -1,0 +1,75 @@
+import { and, eq } from 'drizzle-orm'
+import { db } from '~/server/db'
+import { posTableModel, posSaleModel } from '~/server/db/schemas/pos'
+import type { InsertPosTable, UpdatePosTable, PosTableStatus } from '~/server/db/schemas/pos'
+
+export class PosTablesRepository {
+  async getTables(organizationId: string, sucursalId?: string) {
+    return db
+      .select()
+      .from(posTableModel)
+      .where(
+        and(
+          eq(posTableModel.organizationId, organizationId),
+          eq(posTableModel.isActive, true),
+          ...(sucursalId ? [eq(posTableModel.sucursalId, sucursalId)] : [])
+        )
+      )
+  }
+
+  async getTableById(id: string) {
+    const [table] = await db
+      .select()
+      .from(posTableModel)
+      .where(eq(posTableModel.id, id))
+    return table ?? null
+  }
+
+  async createTable(data: Omit<InsertPosTable, 'id' | 'createdAt' | 'updatedAt'>) {
+    const [table] = await db
+      .insert(posTableModel)
+      .values(data)
+      .returning()
+    return table
+  }
+
+  async updateTable(id: string, data: Partial<UpdatePosTable>) {
+    const [table] = await db
+      .update(posTableModel)
+      .set(data)
+      .where(eq(posTableModel.id, id))
+      .returning()
+    return table
+  }
+
+  async deleteTable(id: string) {
+    await db
+      .update(posTableModel)
+      .set({ isActive: false })
+      .where(eq(posTableModel.id, id))
+  }
+
+  async updateTableStatus(id: string, status: PosTableStatus) {
+    const [table] = await db
+      .update(posTableModel)
+      .set({ status })
+      .where(eq(posTableModel.id, id))
+      .returning()
+    return table
+  }
+
+  async getActiveOrderForTable(tableId: string) {
+    const [sale] = await db
+      .select()
+      .from(posSaleModel)
+      .where(
+        and(
+          eq(posSaleModel.tableId, tableId),
+          eq(posSaleModel.status, 'open')
+        )
+      )
+    return sale ?? null
+  }
+}
+
+export const posTablesRepository = new PosTablesRepository()

--- a/app/i18n/locales/en/sidebar.ts
+++ b/app/i18n/locales/en/sidebar.ts
@@ -50,6 +50,7 @@ export const sidebar = {
   'sidebar.items.posCashiers': 'Cashiers',
   'sidebar.items.posTerminals': 'Terminals',
   'sidebar.items.posTables': 'Tables',
+  'sidebar.items.kitchen': 'Kitchen',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Branch Inventory',
   'sidebar.items.modules': 'Modules',

--- a/app/i18n/locales/en/sidebar.ts
+++ b/app/i18n/locales/en/sidebar.ts
@@ -49,6 +49,7 @@ export const sidebar = {
   'sidebar.items.quotations': 'Quotations',
   'sidebar.items.posCashiers': 'Cashiers',
   'sidebar.items.posTerminals': 'Terminals',
+  'sidebar.items.posTables': 'Tables',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Branch Inventory',
   'sidebar.items.modules': 'Modules',

--- a/app/i18n/locales/es/sidebar.ts
+++ b/app/i18n/locales/es/sidebar.ts
@@ -50,6 +50,7 @@ export const sidebar = {
   'sidebar.items.posCashiers': 'Cajeros',
   'sidebar.items.posTerminals': 'Terminales',
   'sidebar.items.posTables': 'Mesas',
+  'sidebar.items.kitchen': 'Cocina',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Inventario por Sucursal',
   'sidebar.items.modules': 'Módulos',

--- a/app/i18n/locales/es/sidebar.ts
+++ b/app/i18n/locales/es/sidebar.ts
@@ -49,6 +49,7 @@ export const sidebar = {
   'sidebar.items.quotations': 'Cótizaciones',
   'sidebar.items.posCashiers': 'Cajeros',
   'sidebar.items.posTerminals': 'Terminales',
+  'sidebar.items.posTables': 'Mesas',
   'sidebar.items.sucursal': 'Sucursal',
   'sidebar.items.inventorySucursal': 'Inventario por Sucursal',
   'sidebar.items.modules': 'Módulos',

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -185,6 +185,7 @@ export default [
       route('/terminals', './routes/pos-settings/terminals.tsx'),
       route('/cashiers', './routes/pos-settings/cashiers.tsx'),
       route('/exchange-rates', './routes/pos-settings/exchange-rates.tsx'),
+      route('/tables', './routes/pos-settings/tables.tsx'),
     ]),
 
     // Sucursal Routes

--- a/app/routes/kitchen/$sucursalId.tsx
+++ b/app/routes/kitchen/$sucursalId.tsx
@@ -1,8 +1,15 @@
 import { useRevalidator } from 'react-router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { kitchenRepository } from '~/features/kitchen/server/repository'
-import { updateTicketStatusAction, updateItemStatusAction } from '~/features/kitchen/server/actions/update-ticket-status.action'
-import { updateTicketStatusSchema, updateItemStatusSchema } from '~/features/kitchen/schemas'
+import {
+  updateTicketStatusAction,
+  updateItemStatusAction,
+} from '~/features/kitchen/server/actions/update-ticket-status.action'
+import {
+  updateTicketStatusSchema,
+  updateItemStatusSchema,
+} from '~/features/kitchen/schemas'
+import { cn } from '~/lib/utils'
 import type { Route } from './+types/$sucursalId'
 
 export async function loader({ params }: Route.LoaderArgs) {
@@ -40,143 +47,272 @@ export async function action({ request }: Route.ActionArgs) {
   return { error: 'Unknown intent' }
 }
 
+// ── Elapsed time hook ────────────────────────────────────────────────────────
+function useElapsed(createdAt: Date | string | null) {
+  const [elapsed, setElapsed] = useState('')
+
+  useEffect(() => {
+    if (!createdAt) return
+    const update = () => {
+      const diff = Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000)
+      if (diff < 60) setElapsed(`${diff}s`)
+      else if (diff < 3600) setElapsed(`${Math.floor(diff / 60)}m ${diff % 60}s`)
+      else setElapsed(`${Math.floor(diff / 3600)}h ${Math.floor((diff % 3600) / 60)}m`)
+    }
+    update()
+    const id = setInterval(update, 1000)
+    return () => clearInterval(id)
+  }, [createdAt])
+
+  return elapsed
+}
+
+// ── Ticket card ──────────────────────────────────────────────────────────────
+type Modification = { type: string; name: string }
+
+interface TicketCardProps {
+  ticket: {
+    id: string
+    ticketNumber: number
+    notes: string | null
+    createdAt: Date | string | null
+    tableNumber: string | null
+    orderType: string | null
+    status: string
+    items: Array<{
+      id: string
+      productName: string
+      quantity: string
+      status: string
+      modificationsJson: unknown
+    }>
+  }
+  sucursalId: string
+  nextStatus: string
+  nextLabel: string
+  accentClass: string
+  borderClass: string
+  bgClass: string
+}
+
+function TicketCard({
+  ticket,
+  sucursalId,
+  nextStatus,
+  nextLabel,
+  accentClass,
+  borderClass,
+  bgClass,
+}: TicketCardProps) {
+  const elapsed = useElapsed(ticket.createdAt)
+  const allItemsDone = ticket.items.every((i) => i.status === 'ready')
+  const elapsedSecs = ticket.createdAt
+    ? Math.floor((Date.now() - new Date(ticket.createdAt).getTime()) / 1000)
+    : 0
+
+  return (
+    <div className={cn('rounded-xl border-2 p-4 space-y-3', borderClass, bgClass)}>
+      {/* Header */}
+      <div className='flex items-start justify-between gap-2'>
+        <div>
+          <span className={cn('text-2xl font-bold', accentClass)}>
+            #{ticket.ticketNumber}
+          </span>
+          <div className='flex items-center gap-2 mt-0.5'>
+            {ticket.tableNumber ? (
+              <span className='text-xs font-medium bg-white/10 px-2 py-0.5 rounded-full'>
+                Mesa {ticket.tableNumber}
+              </span>
+            ) : (
+              <span className='text-xs text-gray-400'>Para llevar</span>
+            )}
+            {elapsed && (
+              <span
+                className={cn(
+                  'text-xs tabular-nums',
+                  elapsedSecs > 600 ? 'text-red-400 font-bold' : 'text-gray-400'
+                )}
+              >
+                {elapsed}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <form method='post' action={`/kitchen/${sucursalId}`}>
+          <input type='hidden' name='intent' value='update-ticket' />
+          <input type='hidden' name='ticketId' value={ticket.id} />
+          <input type='hidden' name='status' value={nextStatus} />
+          <button
+            type='submit'
+            disabled={nextStatus === 'ready' && !allItemsDone}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-sm font-semibold transition-colors',
+              nextStatus === 'in_progress' &&
+                'bg-yellow-500 text-black hover:bg-yellow-400',
+              nextStatus === 'ready' &&
+                'bg-green-500 text-white hover:bg-green-400 disabled:opacity-40 disabled:cursor-not-allowed',
+              nextStatus === 'served' &&
+                'bg-gray-500 text-white hover:bg-gray-400'
+            )}
+          >
+            {nextLabel}
+          </button>
+        </form>
+      </div>
+
+      {/* Notes */}
+      {ticket.notes && (
+        <p className='text-xs text-gray-300 italic border-l-2 border-gray-600 pl-2'>
+          {ticket.notes}
+        </p>
+      )}
+
+      {/* Items */}
+      <ul className='space-y-2'>
+        {ticket.items.map((item) => {
+          const mods = Array.isArray(item.modificationsJson)
+            ? (item.modificationsJson as Modification[])
+            : []
+          const removals = mods.filter((m) => m.type === 'remove')
+          const isDone = item.status === 'ready'
+
+          return (
+            <li key={item.id} className='space-y-0.5'>
+              <div className='flex items-center gap-2'>
+                {ticket.status === 'in_progress' && !isDone && (
+                  <form method='post' action={`/kitchen/${sucursalId}`}>
+                    <input type='hidden' name='intent' value='update-item' />
+                    <input type='hidden' name='itemId' value={item.id} />
+                    <input type='hidden' name='status' value='ready' />
+                    <button
+                      type='submit'
+                      className='size-5 rounded border border-gray-500 text-xs hover:border-green-400 hover:text-green-400 flex items-center justify-center flex-shrink-0'
+                    >
+                      ✓
+                    </button>
+                  </form>
+                )}
+                {isDone && (
+                  <span className='size-5 flex items-center justify-center text-green-400 flex-shrink-0'>
+                    ✓
+                  </span>
+                )}
+                <span className={cn('text-sm', isDone && 'line-through text-gray-500')}>
+                  <span className='text-base font-bold'>{item.quantity}×</span>{' '}
+                  {item.productName}
+                </span>
+              </div>
+              {removals.length > 0 && (
+                <ul className='ml-7 space-y-0.5'>
+                  {removals.map((r, idx) => (
+                    <li key={idx} className='text-xs text-red-400'>
+                      — Sin {r.name}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+// ── Column config ────────────────────────────────────────────────────────────
+const COLUMNS = [
+  {
+    status: 'pending' as const,
+    label: 'Pendientes',
+    labelClass: 'text-yellow-400',
+    emptyText: 'Sin pedidos pendientes',
+    nextStatus: 'in_progress',
+    nextLabel: 'Iniciar',
+    accentClass: 'text-yellow-400',
+    borderClass: 'border-yellow-500/40',
+    bgClass: 'bg-yellow-950/20',
+  },
+  {
+    status: 'in_progress' as const,
+    label: 'En proceso',
+    labelClass: 'text-blue-400',
+    emptyText: 'Nada en proceso',
+    nextStatus: 'ready',
+    nextLabel: 'Listo',
+    accentClass: 'text-blue-400',
+    borderClass: 'border-blue-500/40',
+    bgClass: 'bg-blue-950/20',
+  },
+  {
+    status: 'ready' as const,
+    label: 'Listo para servir',
+    labelClass: 'text-green-400',
+    emptyText: 'Nada esperando servicio',
+    nextStatus: 'served',
+    nextLabel: 'Servido',
+    accentClass: 'text-green-400',
+    borderClass: 'border-green-500/40',
+    bgClass: 'bg-green-950/20',
+  },
+]
+
+// ── Main page ────────────────────────────────────────────────────────────────
 export default function KitchenDisplay({ loaderData }: Route.ComponentProps) {
   const { tickets, sucursalId } = loaderData
   const { revalidate } = useRevalidator()
 
-  // Poll every 10 seconds (Cloudflare Workers compatible — no SSE/WebSocket)
   useEffect(() => {
-    const interval = setInterval(() => {
-      revalidate()
-    }, 10000)
-    return () => clearInterval(interval)
+    const id = setInterval(() => revalidate(), 5000)
+    return () => clearInterval(id)
   }, [revalidate])
 
-  const pending = tickets.filter((t) => t.status === 'pending')
-  const inProgress = tickets.filter((t) => t.status === 'in_progress')
+  const total = tickets.length
 
   return (
     <div className='flex h-screen flex-col bg-gray-950 text-white'>
-      {/* Header */}
       <div className='flex items-center justify-between border-b border-gray-800 px-6 py-3'>
-        <h1 className='text-xl font-bold'>Cocina</h1>
-        <span className='text-sm text-gray-400'>
-          {tickets.length} pedidos activos
-        </span>
+        <h1 className='text-xl font-bold tracking-tight'>Cocina</h1>
+        <div className='flex items-center gap-3 text-sm text-gray-400'>
+          <span>
+            {total} pedido{total !== 1 ? 's' : ''} activo{total !== 1 ? 's' : ''}
+          </span>
+          <span className='size-2 rounded-full bg-green-500 animate-pulse' />
+        </div>
       </div>
 
-      {/* Board */}
-      <div className='flex flex-1 overflow-hidden'>
-        {/* Pending column */}
-        <div className='flex flex-1 flex-col border-r border-gray-800'>
-          <div className='border-b border-gray-800 px-4 py-2'>
-            <h2 className='font-semibold text-yellow-400'>
-              Pendientes ({pending.length})
-            </h2>
-          </div>
-          <div className='flex-1 overflow-y-auto p-3 space-y-3'>
-            {pending.map((ticket) => (
-              <div
-                key={ticket.id}
-                className='rounded-lg border border-yellow-500/30 bg-yellow-950/20 p-3'
-              >
-                <div className='mb-2 flex items-center justify-between'>
-                  <span className='text-lg font-bold text-yellow-400'>
-                    #{ticket.ticketNumber}
-                  </span>
-                  <form method='post' action={`/kitchen/${sucursalId}`}>
-                    <input type='hidden' name='intent' value='update-ticket' />
-                    <input type='hidden' name='ticketId' value={ticket.id} />
-                    <input type='hidden' name='status' value='in_progress' />
-                    <button
-                      type='submit'
-                      className='rounded bg-yellow-500 px-2 py-1 text-xs font-medium text-black hover:bg-yellow-400'
-                    >
-                      Iniciar
-                    </button>
-                  </form>
-                </div>
-                {ticket.notes && (
-                  <p className='mb-2 text-xs text-gray-400'>{ticket.notes}</p>
-                )}
-                <ul className='space-y-1'>
-                  {ticket.items.map((item) => (
-                    <li key={item.id} className='text-sm'>
-                      <span className='font-medium'>
-                        {item.quantity}x {item.productName}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
+      <div className='flex flex-1 overflow-hidden divide-x divide-gray-800'>
+        {COLUMNS.map((col) => {
+          const colTickets = tickets.filter((t) => t.status === col.status)
+          return (
+            <div key={col.status} className='flex flex-1 flex-col min-w-0'>
+              <div className='border-b border-gray-800 px-4 py-2 flex items-center justify-between'>
+                <h2 className={cn('font-semibold', col.labelClass)}>{col.label}</h2>
+                <span className='text-xs text-gray-500'>{colTickets.length}</span>
               </div>
-            ))}
-          </div>
-        </div>
-
-        {/* In Progress column */}
-        <div className='flex flex-1 flex-col'>
-          <div className='border-b border-gray-800 px-4 py-2'>
-            <h2 className='font-semibold text-blue-400'>
-              En proceso ({inProgress.length})
-            </h2>
-          </div>
-          <div className='flex-1 overflow-y-auto p-3 space-y-3'>
-            {inProgress.map((ticket) => (
-              <div
-                key={ticket.id}
-                className='rounded-lg border border-blue-500/30 bg-blue-950/20 p-3'
-              >
-                <div className='mb-2 flex items-center justify-between'>
-                  <span className='text-lg font-bold text-blue-400'>
-                    #{ticket.ticketNumber}
-                  </span>
-                  <form method='post' action={`/kitchen/${sucursalId}`}>
-                    <input type='hidden' name='intent' value='update-ticket' />
-                    <input type='hidden' name='ticketId' value={ticket.id} />
-                    <input type='hidden' name='status' value='ready' />
-                    <button
-                      type='submit'
-                      className='rounded bg-green-500 px-2 py-1 text-xs font-medium text-white hover:bg-green-400'
-                    >
-                      Listo
-                    </button>
-                  </form>
-                </div>
-                {ticket.notes && (
-                  <p className='mb-2 text-xs text-gray-400'>{ticket.notes}</p>
+              <div className='flex-1 overflow-y-auto p-3 space-y-3'>
+                {colTickets.length === 0 ? (
+                  <p className='text-center text-xs text-gray-600 mt-8'>
+                    {col.emptyText}
+                  </p>
+                ) : (
+                  colTickets.map((ticket) => (
+                    <TicketCard
+                      key={ticket.id}
+                      ticket={ticket}
+                      sucursalId={sucursalId}
+                      nextStatus={col.nextStatus}
+                      nextLabel={col.nextLabel}
+                      accentClass={col.accentClass}
+                      borderClass={col.borderClass}
+                      bgClass={col.bgClass}
+                    />
+                  ))
                 )}
-                <ul className='space-y-1'>
-                  {ticket.items.map((item) => (
-                    <li key={item.id} className='flex items-center gap-2 text-sm'>
-                      <span
-                        className={
-                          item.status === 'ready'
-                            ? 'text-green-400 line-through'
-                            : ''
-                        }
-                      >
-                        {item.quantity}x {item.productName}
-                      </span>
-                      {item.status !== 'ready' && (
-                        <form method='post' action={`/kitchen/${sucursalId}`}>
-                          <input type='hidden' name='intent' value='update-item' />
-                          <input type='hidden' name='itemId' value={item.id} />
-                          <input type='hidden' name='status' value='ready' />
-                          <button
-                            type='submit'
-                            className='text-xs text-gray-400 hover:text-green-400'
-                          >
-                            ✓
-                          </button>
-                        </form>
-                      )}
-                    </li>
-                  ))}
-                </ul>
               </div>
-            ))}
-          </div>
-        </div>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/app/routes/kitchen/index.tsx
+++ b/app/routes/kitchen/index.tsx
@@ -1,9 +1,44 @@
 import { redirect } from 'react-router'
+import { getPosSession } from '~/server/auth/pos-session.server'
+import { getOptionalAuth } from '~/server/auth/session.server'
+import { db } from '~/server/db'
+import { sucursalModel } from '~/server/db/schemas/sucursal'
+import { eq } from 'drizzle-orm'
+import type { Route } from './+types/index'
 
-export async function loader() {
-  return redirect('/sucursal')
+export async function loader({ request }: Route.LoaderArgs) {
+  const [userSession, posSession] = await Promise.all([
+    getOptionalAuth(request),
+    getPosSession(request),
+  ])
+
+  if (!userSession && !posSession) throw redirect('/pos-login')
+
+  const organizationId =
+    posSession?.organizationId ?? userSession?.session.activeOrganizationId
+
+  if (!organizationId) throw redirect('/pos-login')
+
+  const [firstSucursal] = await db
+    .select({ id: sucursalModel.id })
+    .from(sucursalModel)
+    .where(eq(sucursalModel.organizationId, organizationId))
+    .limit(1)
+
+  if (firstSucursal) throw redirect(`/kitchen/${firstSucursal.id}`)
+
+  return {}
 }
 
 export default function KitchenIndex() {
-  return null
+  return (
+    <div className='flex h-screen items-center justify-center bg-gray-950 text-white'>
+      <div className='text-center space-y-2'>
+        <h2 className='text-xl font-bold'>Sin sucursales configuradas</h2>
+        <p className='text-gray-400 text-sm'>
+          Configurá una sucursal en Ajustes para usar el display de cocina.
+        </p>
+      </div>
+    </div>
+  )
 }

--- a/app/routes/pos-settings/cashiers.tsx
+++ b/app/routes/pos-settings/cashiers.tsx
@@ -22,7 +22,7 @@ import {
 } from '~/components/ui/select'
 import { posRepository } from '~/features/pos/server/repository'
 import { createCashierSchema } from '~/features/pos/schemas'
-import { requireAuth } from '~/server/auth/session.server'
+import { requireModule } from '~/server/auth/module.server'
 import { useTranslation } from '~/i18n/context'
 import { db } from '~/server/db'
 import { userModel, memberModel } from '~/server/db/schemas/auth'
@@ -38,7 +38,7 @@ interface CashierRow {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await requireAuth(request)
+  const session = await requireModule(request, 'pos')
   const organizationId = session.session.activeOrganizationId
 
   if (!organizationId) {
@@ -58,7 +58,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await requireAuth(request)
+  await requireModule(request, 'pos')
   const formData = await request.formData()
   const intent = formData.get('intent')
 

--- a/app/routes/pos-settings/exchange-rates.tsx
+++ b/app/routes/pos-settings/exchange-rates.tsx
@@ -2,11 +2,11 @@ import { Form, useActionData } from 'react-router'
 import { exchangeRateRepository } from '~/features/exchangeRate/server/repository'
 import { setExchangeRateSchema } from '~/features/exchangeRate/schemas'
 import { setExchangeRateAction } from '~/features/exchangeRate/server/actions/set-exchange-rate.action'
-import { requireAuth } from '~/server/auth/session.server'
+import { requireModule } from '~/server/auth/module.server'
 import type { Route } from './+types/exchange-rates'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await requireAuth(request)
+  const session = await requireModule(request, 'pos')
   const organizationId = session.session.activeOrganizationId!
 
   const [activeUsdRate, rateHistory] = await Promise.all([
@@ -18,7 +18,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const session = await requireAuth(request)
+  const session = await requireModule(request, 'pos')
   const organizationId = session.session.activeOrganizationId!
   const formData = await request.formData()
 

--- a/app/routes/pos-settings/tables.tsx
+++ b/app/routes/pos-settings/tables.tsx
@@ -1,0 +1,293 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { Form, useFetcher, useNavigation } from 'react-router'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { DataTable } from '~/components/dataTable/DataTable'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select'
+import { createTableSchema, updateTableSchema } from '~/features/pos/schemas'
+import { posTablesRepository } from '~/features/pos/server/repository/tables.repository'
+import { requireModule } from '~/server/auth/module.server'
+import { db } from '~/server/db'
+import { sucursalModel } from '~/server/db/schemas/sucursal'
+import { eq } from 'drizzle-orm'
+import type { PosTable } from '~/server/db/schemas/pos'
+import type { Route } from './+types/tables'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const session = await requireModule(request, 'pos')
+  const organizationId = session.session.activeOrganizationId
+
+  if (!organizationId) return { tables: [], sucursales: [], organizationId: null }
+
+  const [tables, sucursales] = await Promise.all([
+    posTablesRepository.getTables(organizationId),
+    db
+      .select({ id: sucursalModel.id, name: sucursalModel.name })
+      .from(sucursalModel)
+      .where(eq(sucursalModel.organizationId, organizationId))
+      .orderBy(sucursalModel.name),
+  ])
+
+  return { tables, sucursales, organizationId }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  await requireModule(request, 'pos')
+  const formData = await request.formData()
+  const intent = formData.get('intent')
+
+  if (intent === 'create') {
+    const parsed = createTableSchema.safeParse({
+      number: formData.get('number'),
+      organizationId: formData.get('organizationId'),
+      sucursalId: formData.get('sucursalId') || null,
+      capacity: formData.get('capacity') || null,
+    })
+    if (!parsed.success) return { error: 'Datos inválidos', fieldErrors: parsed.error.flatten().fieldErrors }
+    await posTablesRepository.createTable(parsed.data)
+    return { success: true }
+  }
+
+  if (intent === 'update') {
+    const id = formData.get('id') as string
+    const parsed = updateTableSchema.safeParse({
+      number: formData.get('number'),
+      sucursalId: formData.get('sucursalId') || null,
+      capacity: formData.get('capacity') || null,
+    })
+    if (!parsed.success) return { error: 'Datos inválidos', fieldErrors: parsed.error.flatten().fieldErrors }
+    await posTablesRepository.updateTable(id, parsed.data)
+    return { success: true }
+  }
+
+  if (intent === 'delete') {
+    const id = formData.get('id') as string
+    await posTablesRepository.deleteTable(id)
+    return { success: true }
+  }
+
+  return { error: 'Acción desconocida' }
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  available: 'Disponible',
+  occupied: 'Ocupada',
+  reserved: 'Reservada',
+}
+
+const STATUS_VARIANTS: Record<string, 'default' | 'secondary' | 'outline'> = {
+  available: 'default',
+  occupied: 'secondary',
+  reserved: 'outline',
+}
+
+export default function PosTablesPage({ loaderData }: Route.ComponentProps) {
+  const { tables, sucursales, organizationId } = loaderData as {
+    tables: PosTable[]
+    sucursales: Array<{ id: string; name: string }>
+    organizationId: string | null
+  }
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingTable, setEditingTable] = useState<PosTable | null>(null)
+  const fetcher = useFetcher()
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state === 'submitting'
+
+  const columns: ColumnDef<PosTable>[] = [
+    {
+      accessorKey: 'number',
+      header: 'Mesa',
+      cell: ({ row }) => (
+        <span className='font-medium'>Mesa {row.original.number}</span>
+      ),
+    },
+    {
+      accessorKey: 'capacity',
+      header: 'Capacidad',
+      cell: ({ row }) =>
+        row.original.capacity ? `${row.original.capacity} personas` : '-',
+    },
+    {
+      accessorKey: 'status',
+      header: 'Estado',
+      cell: ({ row }) => (
+        <Badge variant={STATUS_VARIANTS[row.original.status] ?? 'outline'}>
+          {STATUS_LABELS[row.original.status] ?? row.original.status}
+        </Badge>
+      ),
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <div className='flex items-center gap-1'>
+          <Button
+            variant='ghost'
+            size='icon-xs'
+            type='button'
+            onClick={() => setEditingTable(row.original)}
+          >
+            <Pencil className='size-4' />
+          </Button>
+          <fetcher.Form method='post'>
+            <input type='hidden' name='intent' value='delete' />
+            <input type='hidden' name='id' value={row.original.id} />
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              type='submit'
+              className='text-destructive'
+            >
+              <Trash2 className='size-4' />
+            </Button>
+          </fetcher.Form>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div className='page-container space-y-6'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h1 className='text-xl font-bold'>Mesas</h1>
+          <p className='text-muted-foreground text-sm'>
+            Configurá las mesas disponibles en tu restaurante
+          </p>
+        </div>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className='size-4' />
+          Nueva mesa
+        </Button>
+      </div>
+
+      <DataTable columns={columns} data={tables} />
+
+      {/* Create dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nueva mesa</DialogTitle>
+          </DialogHeader>
+          <Form
+            method='post'
+            onSubmit={() => setTimeout(() => setDialogOpen(false), 200)}
+          >
+            <input type='hidden' name='intent' value='create' />
+            <input type='hidden' name='organizationId' value={organizationId ?? ''} />
+
+            <div className='space-y-4'>
+              <div>
+                <label className='text-sm font-medium'>Número / Nombre</label>
+                <Input name='number' placeholder='1, A1, Terraza 3…' required className='mt-1' />
+              </div>
+              <div>
+                <label className='text-sm font-medium'>Capacidad (personas)</label>
+                <Input name='capacity' type='number' min='1' placeholder='4' className='mt-1' />
+              </div>
+              {sucursales.length > 0 && (
+                <div>
+                  <label className='text-sm font-medium'>Sucursal</label>
+                  <Select name='sucursalId'>
+                    <SelectTrigger className='mt-1'>
+                      <SelectValue placeholder='Seleccionar sucursal (opcional)' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sucursales.map((s) => (
+                        <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+
+            <DialogFooter className='mt-6'>
+              <Button variant='outline' type='button' onClick={() => setDialogOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type='submit' disabled={isSubmitting}>
+                {isSubmitting ? 'Creando…' : 'Crear mesa'}
+              </Button>
+            </DialogFooter>
+          </Form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={!!editingTable} onOpenChange={(open) => !open && setEditingTable(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Editar mesa {editingTable?.number}</DialogTitle>
+          </DialogHeader>
+          {editingTable && (
+            <Form
+              method='post'
+              onSubmit={() => setTimeout(() => setEditingTable(null), 200)}
+            >
+              <input type='hidden' name='intent' value='update' />
+              <input type='hidden' name='id' value={editingTable.id} />
+
+              <div className='space-y-4'>
+                <div>
+                  <label className='text-sm font-medium'>Número / Nombre</label>
+                  <Input name='number' defaultValue={editingTable.number} required className='mt-1' />
+                </div>
+                <div>
+                  <label className='text-sm font-medium'>Capacidad (personas)</label>
+                  <Input
+                    name='capacity'
+                    type='number'
+                    min='1'
+                    defaultValue={editingTable.capacity ?? ''}
+                    className='mt-1'
+                  />
+                </div>
+                {sucursales.length > 0 && (
+                  <div>
+                    <label className='text-sm font-medium'>Sucursal</label>
+                    <Select name='sucursalId' defaultValue={editingTable.sucursalId ?? undefined}>
+                      <SelectTrigger className='mt-1'>
+                        <SelectValue placeholder='Seleccionar sucursal (opcional)' />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {sucursales.map((s) => (
+                          <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </div>
+
+              <DialogFooter className='mt-6'>
+                <Button variant='outline' type='button' onClick={() => setEditingTable(null)}>
+                  Cancelar
+                </Button>
+                <Button type='submit' disabled={isSubmitting}>
+                  {isSubmitting ? 'Guardando…' : 'Guardar'}
+                </Button>
+              </DialogFooter>
+            </Form>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/routes/pos-settings/terminals.tsx
+++ b/app/routes/pos-settings/terminals.tsx
@@ -26,7 +26,7 @@ import {
   createTerminalSchema,
   updateTerminalSchema,
 } from '~/features/pos/schemas'
-import { requireAuth } from '~/server/auth/session.server'
+import { requireModule } from '~/server/auth/module.server'
 import { useTranslation } from '~/i18n/context'
 import type { Route } from './+types/terminals'
 import type { PosTerminalWithSucursal } from '~/features/pos/types'
@@ -37,7 +37,7 @@ import { companyModel } from '~/server/db/schemas/company'
 import { eq } from 'drizzle-orm'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await requireAuth(request)
+  const session = await requireModule(request, 'pos')
   const organizationId = session.session.activeOrganizationId
 
   if (!organizationId) {
@@ -79,7 +79,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await requireAuth(request)
+  await requireModule(request, 'pos')
   const formData = await request.formData()
   const intent = formData.get('intent')
 

--- a/app/routes/pos/terminal.tsx
+++ b/app/routes/pos/terminal.tsx
@@ -52,6 +52,8 @@ import { db } from '~/server/db'
 import { and, eq } from 'drizzle-orm'
 import type { Route } from './+types/terminal'
 import { PosProductRecipeDialog } from '~/features/pos/components/PosProductRecipeDialog'
+import { PosTableSelectionView } from '~/features/pos/components/PosTableSelectionView'
+import type { PosTable } from '~/server/db/schemas/pos'
 
 export async function loader({ request }: Route.LoaderArgs) {
   const [userSession, posSession] = await Promise.all([
@@ -105,7 +107,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const sucursalId = terminal.sucursalId ?? undefined
 
-  const [products, categories, expectedCash, activeExchangeRate] =
+  const [products, categories, expectedCash, activeExchangeRate, tables] =
     await Promise.all([
       posRepository.getProductsForPos(organizationId, sucursalId),
       posRepository.getCategories(organizationId),
@@ -113,6 +115,8 @@ export async function loader({ request }: Route.LoaderArgs) {
         ? posRepository.calculateExpectedCashForSession(openSession.id)
         : Promise.resolve(0),
       exchangeRateRepository.getActiveRate(organizationId, 'USD', 'GTQ'),
+      (await import('~/features/pos/server/repository/tables.repository'))
+        .posTablesRepository.getTables(organizationId, sucursalId),
     ])
 
   // Fetch combo definitions for combo products
@@ -167,6 +171,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     activeExchangeRate: activeExchangeRate
       ? Number(activeExchangeRate.rate)
       : null,
+    tables,
   }
 }
 
@@ -390,6 +395,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
     expectedCash,
     comboDefinitions,
     activeExchangeRate,
+    tables,
   } = loaderData
 
   const { t } = useTranslation()
@@ -433,6 +439,26 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
     useState<PosProductForGrid | null>(null)
   const [recipeDialogProduct, setRecipeDialogProduct] =
     useState<PosProductForGrid | null>(null)
+
+  // Table / order type selection
+  const [selectedTable, setSelectedTable] = useState<PosTable | null>(null)
+  const [orderType, setOrderType] = useState<'dine_in' | 'takeout' | 'delivery' | null>(null)
+  const hasTables = (tables as PosTable[]).length > 0
+  // Show table selection when session is open and no order type chosen yet
+  const showTableSelection = !!openSession && hasTables && orderType === null
+
+  const handleSelectTable = (table: PosTable) => {
+    setSelectedTable(table)
+    setOrderType('dine_in')
+  }
+  const handleTakeout = () => {
+    setSelectedTable(null)
+    setOrderType('takeout')
+  }
+  const resetTableSelection = () => {
+    setSelectedTable(null)
+    setOrderType(null)
+  }
 
   // No cashier profile
   if (!cashier) {
@@ -713,6 +739,8 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
         businessPartnerId,
         idempotencyKey: crypto.randomUUID(),
         sessionId: openSession?.id,
+        tableId: selectedTable?.id ?? null,
+        orderType: orderType ?? 'takeout',
         lines: cart.map((item) => ({
           productId: item.productId,
           productName: item.productName,
@@ -747,6 +775,8 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
       cashierId,
       userId,
       openSession,
+      selectedTable,
+      orderType,
       fetcher,
       t,
     ]
@@ -858,6 +888,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
     setNumpadInput('')
     setSelectedCustomer(null)
     setPaymentOpen(false)
+    resetTableSelection()
 
     if (terminal.autoPrintReceipt) {
       handlePrint(receipt)
@@ -909,6 +940,13 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
         onCashMovement={() => setCashMovementOpen(true)}
       />
 
+      {showTableSelection ? (
+        <PosTableSelectionView
+          tables={tables as PosTable[]}
+          onSelectTable={handleSelectTable}
+          onTakeout={handleTakeout}
+        />
+      ) : (
       <div className='flex flex-1 overflow-hidden'>
         {/* Left panel: Products */}
         <div className='flex flex-1 flex-col gap-3 overflow-hidden border-r p-4'>
@@ -960,6 +998,7 @@ export default function PosTerminal({ loaderData }: Route.ComponentProps) {
           />
         </div>
       </div>
+      )}
 
       <PosPaymentDialog
         open={paymentOpen}

--- a/app/routes/settings/modules.tsx
+++ b/app/routes/settings/modules.tsx
@@ -49,11 +49,25 @@ export async function action({ request }: Route.ActionArgs) {
     return { error: 'Invalid data' }
   }
 
+  const isActive = result.data.isActive as boolean
+
   await modulesRepository.setOrgModuleActive(
     result.data.organizationId,
     result.data.moduleKey,
-    result.data.isActive as boolean
+    isActive
   )
+
+  if (isActive) {
+    await modulesRepository.autoGrantMemberAccess(
+      result.data.organizationId,
+      result.data.moduleKey
+    )
+  } else {
+    await modulesRepository.revokeAllMembersAccess(
+      result.data.organizationId,
+      result.data.moduleKey
+    )
+  }
 
   return redirectWithFlash('/settings/modules', {
     type: 'success',

--- a/app/server/auth/module.server.test.ts
+++ b/app/server/auth/module.server.test.ts
@@ -73,11 +73,13 @@ const makeSelectChain = (resolvedValue: unknown) => {
 describe('requireModule', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  test('super admin bypasses module check', async () => {
-    mockRequireAuth.mockResolvedValue(makeSession({ isSuperAdmin: true }))
+  test('super admin bypasses module check and returns session', async () => {
+    const session = makeSession({ isSuperAdmin: true })
+    mockRequireAuth.mockResolvedValue(session)
 
-    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+    const result = await requireModule(makeRequest(), 'pos')
 
+    expect(result).toEqual(session)
     expect(mockGetMemberAccessLevel).not.toHaveBeenCalled()
   })
 
@@ -97,24 +99,28 @@ describe('requireModule', () => {
     await expect(requireModule(makeRequest(), 'pos')).rejects.toBeInstanceOf(Response)
   })
 
-  test('allows access when member has user access', async () => {
-    mockRequireAuth.mockResolvedValue(makeSession())
+  test('allows access when member has user access and returns session', async () => {
+    const session = makeSession()
+    mockRequireAuth.mockResolvedValue(session)
     ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
       makeSelectChain([{ id: 'member-1' }])
     )
     mockGetMemberAccessLevel.mockResolvedValue('user')
 
-    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+    const result = await requireModule(makeRequest(), 'pos')
+    expect(result).toEqual(session)
   })
 
-  test('allows access when member has admin access', async () => {
-    mockRequireAuth.mockResolvedValue(makeSession())
+  test('allows access when member has admin access and returns session', async () => {
+    const session = makeSession()
+    mockRequireAuth.mockResolvedValue(session)
     ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
       makeSelectChain([{ id: 'member-1' }])
     )
     mockGetMemberAccessLevel.mockResolvedValue('admin')
 
-    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+    const result = await requireModule(makeRequest(), 'pos')
+    expect(result).toEqual(session)
   })
 
   test('redirects when member record not found', async () => {

--- a/app/server/auth/module.server.test.ts
+++ b/app/server/auth/module.server.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/server/auth/session.server', () => ({
+  requireAuth: vi.fn(),
+}))
+
+vi.mock('~/server/permissions', () => ({
+  isSuperAdmin: vi.fn(),
+}))
+
+vi.mock('~/features/modules/server/repository', () => ({
+  modulesRepository: {
+    getMemberAccessLevel: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}))
+
+vi.mock('~/server/db/schemas/auth', () => ({
+  memberModel: { id: 'id', organizationId: 'organization_id', userId: 'user_id' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args) => args),
+  eq: vi.fn((col, val) => ({ col, val })),
+}))
+
+import { requireAuth } from '~/server/auth/session.server'
+import { modulesRepository } from '~/features/modules/server/repository'
+import { db } from '~/server/db'
+import { requireModule } from './module.server'
+
+const mockRequireAuth = vi.mocked(requireAuth)
+const mockGetMemberAccessLevel = vi.mocked(modulesRepository.getMemberAccessLevel)
+const mockDb = vi.mocked(db)
+
+const makeRequest = () => new Request('http://localhost/pos')
+
+const makeSession = (overrides?: { isSuperAdmin?: boolean; activeOrganizationId?: string | null }) => {
+  const orgId: string | null = overrides && 'activeOrganizationId' in overrides
+    ? (overrides.activeOrganizationId ?? null)
+    : 'org-1'
+  return {
+    session: {
+      userId: 'user-1',
+      token: 'token',
+      expiresAt: new Date(),
+      activeOrganizationId: orgId,
+    },
+    user: {
+      id: 'user-1',
+      email: 'test@test.com',
+      emailVerified: true,
+      name: 'Test User',
+      image: null,
+      isSuperAdmin: overrides?.isSuperAdmin ?? false,
+    },
+  }
+}
+
+const makeSelectChain = (resolvedValue: unknown) => {
+  const chain = { from: vi.fn(), where: vi.fn(), limit: vi.fn() }
+  chain.from.mockReturnValue(chain)
+  chain.where.mockReturnValue(chain)
+  chain.limit.mockResolvedValue(resolvedValue)
+  return chain
+}
+
+describe('requireModule', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('super admin bypasses module check', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession({ isSuperAdmin: true }))
+
+    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+
+    expect(mockGetMemberAccessLevel).not.toHaveBeenCalled()
+  })
+
+  test('redirects when org has no active organization', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession({ activeOrganizationId: null }))
+
+    await expect(requireModule(makeRequest(), 'pos')).rejects.toBeInstanceOf(Response)
+  })
+
+  test('redirects when member has no access to module', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession())
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }])
+    )
+    mockGetMemberAccessLevel.mockResolvedValue('none')
+
+    await expect(requireModule(makeRequest(), 'pos')).rejects.toBeInstanceOf(Response)
+  })
+
+  test('allows access when member has user access', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession())
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }])
+    )
+    mockGetMemberAccessLevel.mockResolvedValue('user')
+
+    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+  })
+
+  test('allows access when member has admin access', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession())
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([{ id: 'member-1' }])
+    )
+    mockGetMemberAccessLevel.mockResolvedValue('admin')
+
+    await expect(requireModule(makeRequest(), 'pos')).resolves.not.toThrow()
+  })
+
+  test('redirects when member record not found', async () => {
+    mockRequireAuth.mockResolvedValue(makeSession())
+    ;(mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeSelectChain([])
+    )
+
+    await expect(requireModule(makeRequest(), 'pos')).rejects.toBeInstanceOf(Response)
+  })
+})

--- a/app/server/auth/module.server.ts
+++ b/app/server/auth/module.server.ts
@@ -1,0 +1,46 @@
+import { redirect } from 'react-router'
+import { and, eq } from 'drizzle-orm'
+import { db } from '~/server/db'
+import { memberModel } from '~/server/db/schemas/auth'
+import { modulesRepository } from '~/features/modules/server/repository'
+import type { ModuleKey } from '~/features/modules/constants'
+import { requireAuth } from './session.server'
+
+/**
+ * Guard that ensures the current user has access to a specific module.
+ * Super admins bypass this check.
+ * Throws a redirect to /home if access is denied.
+ */
+export async function requireModule(request: Request, moduleKey: ModuleKey): Promise<void> {
+  const session = await requireAuth(request)
+
+  // Super admin bypasses all module checks
+  if (session.user.isSuperAdmin) return
+
+  const organizationId = session.session.activeOrganizationId
+  if (!organizationId) {
+    throw redirect('/home')
+  }
+
+  // Get the member record for this user in the active org
+  const [memberRow] = await db
+    .select({ id: memberModel.id })
+    .from(memberModel)
+    .where(
+      and(
+        eq(memberModel.userId, session.user.id),
+        eq(memberModel.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+
+  if (!memberRow) {
+    throw redirect('/home')
+  }
+
+  const accessLevel = await modulesRepository.getMemberAccessLevel(memberRow.id, moduleKey)
+
+  if (accessLevel === 'none') {
+    throw redirect('/home')
+  }
+}

--- a/app/server/auth/module.server.ts
+++ b/app/server/auth/module.server.ts
@@ -4,18 +4,19 @@ import { db } from '~/server/db'
 import { memberModel } from '~/server/db/schemas/auth'
 import { modulesRepository } from '~/features/modules/server/repository'
 import type { ModuleKey } from '~/features/modules/constants'
-import { requireAuth } from './session.server'
+import { requireAuth, type SessionData } from './session.server'
 
 /**
  * Guard that ensures the current user has access to a specific module.
+ * Returns the session so it can replace requireAuth in loaders/actions.
  * Super admins bypass this check.
  * Throws a redirect to /home if access is denied.
  */
-export async function requireModule(request: Request, moduleKey: ModuleKey): Promise<void> {
+export async function requireModule(request: Request, moduleKey: ModuleKey): Promise<SessionData> {
   const session = await requireAuth(request)
 
   // Super admin bypasses all module checks
-  if (session.user.isSuperAdmin) return
+  if (session.user.isSuperAdmin) return session
 
   const organizationId = session.session.activeOrganizationId
   if (!organizationId) {
@@ -43,4 +44,6 @@ export async function requireModule(request: Request, moduleKey: ModuleKey): Pro
   if (accessLevel === 'none') {
     throw redirect('/home')
   }
+
+  return session
 }

--- a/app/server/db/schemas/index.ts
+++ b/app/server/db/schemas/index.ts
@@ -82,6 +82,7 @@ import {
   quotationStatus,
 } from './quotations'
 import {
+  posTableModel,
   posTerminalModel,
   posSaleModel,
   posSaleLineModel,
@@ -204,6 +205,7 @@ export const schema = {
   quotationRecipient: quotationRecipientModel,
 
   // POS tables
+  posTable: posTableModel,
   posTerminal: posTerminalModel,
   posSale: posSaleModel,
   posSaleLine: posSaleLineModel,
@@ -266,6 +268,7 @@ export const schema = {
   quotationRelations,
   quotationDetailRelations,
   quotationRecipientRelations,
+  posTableRelations,
   posTerminalRelations,
   posSaleRelations,
   posSaleLineRelations,

--- a/app/server/db/schemas/index.ts
+++ b/app/server/db/schemas/index.ts
@@ -83,6 +83,7 @@ import {
 } from './quotations'
 import {
   posTableModel,
+  posTableRelations,
   posTerminalModel,
   posSaleModel,
   posSaleLineModel,

--- a/app/server/db/schemas/pos.ts
+++ b/app/server/db/schemas/pos.ts
@@ -28,9 +28,22 @@ import { sucursalModel } from './sucursal'
 
 // Enums
 export const posSaleStatusEnum = pgEnum('pos_sale_status', [
+  'open',
   'completed',
   'voided',
   'refunded',
+])
+
+export const posOrderTypeEnum = pgEnum('pos_order_type', [
+  'dine_in',
+  'takeout',
+  'delivery',
+])
+
+export const posTableStatusEnum = pgEnum('pos_table_status', [
+  'available',
+  'occupied',
+  'reserved',
 ])
 
 export const posPaymentMethodEnum = pgEnum('pos_payment_method', [
@@ -57,6 +70,27 @@ export const posSaleLineTypeEnum = pgEnum('pos_sale_line_type', [
   'combo',
   'combo_item',
 ])
+
+// POS Table (Mesa)
+export const posTableModel = pgTable(
+  'pos_table',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id')
+      .notNull()
+      .references(() => organizationModel.id),
+    sucursalId: uuid('sucursal_id').references(() => sucursalModel.id),
+    number: text('number').notNull(), // "1", "A1", "Terraza 3", etc.
+    capacity: integer('capacity'), // número de asientos
+    status: posTableStatusEnum('status').notNull().default('available'),
+    isActive: boolean('is_active').notNull().default(true),
+    ...timestamps,
+  },
+  (table) => [
+    index('pos_table_org_idx').on(table.organizationId, table.isActive),
+    index('pos_table_sucursal_idx').on(table.sucursalId, table.status),
+  ]
+)
 
 // POS Terminal
 export const posTerminalModel = pgTable('pos_terminal', {
@@ -107,6 +141,9 @@ export const posSaleModel = pgTable('pos_sale', {
   businessPartnerId: uuid('business_partner_id')
     .notNull()
     .references(() => businessPartnerModel.id),
+  tableId: uuid('table_id').references(() => posTableModel.id),
+  orderType: posOrderTypeEnum('order_type').notNull().default('takeout'),
+  coverCount: integer('cover_count'),
   saleNumber: text('sale_number').notNull(),
   idempotencyKey: uuid('idempotency_key'),
   status: posSaleStatusEnum('status').notNull().default('completed'),
@@ -282,6 +319,18 @@ export const posZReportModel = pgTable('pos_z_report', {
 })
 
 // Relations
+export const posTableRelations = relations(posTableModel, ({ one, many }) => ({
+  organization: one(organizationModel, {
+    fields: [posTableModel.organizationId],
+    references: [organizationModel.id],
+  }),
+  sucursal: one(sucursalModel, {
+    fields: [posTableModel.sucursalId],
+    references: [sucursalModel.id],
+  }),
+  sales: many(posSaleModel),
+}))
+
 export const posTerminalRelations = relations(
   posTerminalModel,
   ({ one, many }) => ({
@@ -310,6 +359,10 @@ export const posSaleRelations = relations(posSaleModel, ({ one, many }) => ({
   organization: one(organizationModel, {
     fields: [posSaleModel.organizationId],
     references: [organizationModel.id],
+  }),
+  table: one(posTableModel, {
+    fields: [posSaleModel.tableId],
+    references: [posTableModel.id],
   }),
   sucursal: one(sucursalModel, {
     fields: [posSaleModel.sucursalId],
@@ -438,6 +491,10 @@ export const posZReportRelations = relations(posZReportModel, ({ one }) => ({
 }))
 
 // Schemas
+export const selectPosTableSchema = createSelectSchema(posTableModel)
+export const insertPosTableSchema = createInsertSchema(posTableModel)
+export const updatePosTableSchema = createUpdateSchema(posTableModel)
+
 export const selectPosTerminalSchema = createSelectSchema(posTerminalModel)
 export const insertPosTerminalSchema = createInsertSchema(posTerminalModel)
 export const updatePosTerminalSchema = createUpdateSchema(posTerminalModel)
@@ -465,6 +522,12 @@ export const selectPosZReportSchema = createSelectSchema(posZReportModel)
 export const insertPosZReportSchema = createInsertSchema(posZReportModel)
 
 // Types
+export type PosTable = z.infer<typeof selectPosTableSchema>
+export type InsertPosTable = z.infer<typeof insertPosTableSchema>
+export type UpdatePosTable = z.infer<typeof updatePosTableSchema>
+export type PosTableStatus = 'available' | 'occupied' | 'reserved'
+export type PosOrderType = 'dine_in' | 'takeout' | 'delivery'
+
 export type PosTerminal = z.infer<typeof selectPosTerminalSchema>
 export type InsertPosTerminal = z.infer<typeof insertPosTerminalSchema>
 export type PosSale = z.infer<typeof selectPosSaleSchema>

--- a/drizzle/0030_rainy_turbo.sql
+++ b/drizzle/0030_rainy_turbo.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."pos_order_type" AS ENUM('dine_in', 'takeout', 'delivery');--> statement-breakpoint
+CREATE TYPE "public"."pos_table_status" AS ENUM('available', 'occupied', 'reserved');--> statement-breakpoint
+ALTER TYPE "public"."pos_sale_status" ADD VALUE 'open' BEFORE 'completed';--> statement-breakpoint
+CREATE TABLE "pos_table" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"sucursal_id" uuid,
+	"number" text NOT NULL,
+	"capacity" integer,
+	"status" "pos_table_status" DEFAULT 'available' NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pos_sale" ADD COLUMN "table_id" uuid;--> statement-breakpoint
+ALTER TABLE "pos_sale" ADD COLUMN "order_type" "pos_order_type" DEFAULT 'takeout' NOT NULL;--> statement-breakpoint
+ALTER TABLE "pos_sale" ADD COLUMN "cover_count" integer;--> statement-breakpoint
+ALTER TABLE "pos_table" ADD CONSTRAINT "pos_table_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pos_table" ADD CONSTRAINT "pos_table_sucursal_id_sucursal_id_fk" FOREIGN KEY ("sucursal_id") REFERENCES "public"."sucursal"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "pos_table_org_idx" ON "pos_table" USING btree ("organization_id","is_active");--> statement-breakpoint
+CREATE INDEX "pos_table_sucursal_idx" ON "pos_table" USING btree ("sucursal_id","status");--> statement-breakpoint
+ALTER TABLE "pos_sale" ADD CONSTRAINT "pos_sale_table_id_pos_table_id_fk" FOREIGN KEY ("table_id") REFERENCES "public"."pos_table"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,7389 @@
+{
+  "id": "a374b4ee-7dfa-4707-85cc-dd5d24a828a7",
+  "prevId": "8e6d099d-e0b2-4fb3-aba0-1afe52408de4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_account": {
+      "name": "accounting_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounting_account_organization_id_organization_id_fk": {
+          "name": "accounting_account_organization_id_organization_id_fk",
+          "tableFrom": "accounting_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment": {
+      "name": "appointment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_organization_id_organization_id_fk": {
+          "name": "appointment_organization_id_organization_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_client_id_business_partner_id_fk": {
+          "name": "appointment_client_id_business_partner_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_service_id_service_id_fk": {
+          "name": "appointment_service_id_service_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "service",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_staff_id_member_id_fk": {
+          "name": "appointment_staff_id_member_id_fk",
+          "tableFrom": "appointment",
+          "tableTo": "member",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_permissions": {
+          "name": "custom_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_role": {
+      "name": "invitation_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_role_invitation_id_invitation_id_fk": {
+          "name": "invitation_role_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_role_role_id_role_id_fk": {
+          "name": "invitation_role_role_id_role_id_fk",
+          "tableFrom": "invitation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_role_unique": {
+          "name": "invitation_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_role_member_id_member_id_fk": {
+          "name": "member_role_member_id_member_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_role_role_id_role_id_fk": {
+          "name": "member_role_role_id_role_id_fk",
+          "tableFrom": "member_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_role_unique": {
+          "name": "member_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_domain_unique": {
+          "name": "organization_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission": {
+      "name": "permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_resource_action_idx": {
+          "name": "uq_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_organization_id_organization_id_fk": {
+          "name": "role_organization_id_organization_id_fk",
+          "tableFrom": "role",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permission": {
+      "name": "role_permission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permission_role_id_role_id_fk": {
+          "name": "role_permission_role_id_role_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_permission_id_permission_id_fk": {
+          "name": "role_permission_permission_id_permission_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "permission",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_organization_id_organization_id_fk": {
+          "name": "role_permission_organization_id_organization_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.business_partner": {
+      "name": "business_partner",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_partner_email_org_idx": {
+          "name": "business_partner_email_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "business_partner_nit_org_idx": {
+          "name": "business_partner_nit_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_partner_organization_id_organization_id_fk": {
+          "name": "business_partner_organization_id_organization_id_fk",
+          "tableFrom": "business_partner",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.combo_group_item": {
+      "name": "combo_group_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_adjustment": {
+          "name": "price_adjustment",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "combo_group_item_group_id_combo_group_id_fk": {
+          "name": "combo_group_item_group_id_combo_group_id_fk",
+          "tableFrom": "combo_group_item",
+          "tableTo": "combo_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "combo_group_item_product_id_product_id_fk": {
+          "name": "combo_group_item_product_id_product_id_fk",
+          "tableFrom": "combo_group_item",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.combo_group": {
+      "name": "combo_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "combo_id": {
+          "name": "combo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_select": {
+          "name": "min_select",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "max_select": {
+          "name": "max_select",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "combo_group_combo_id_combo_id_fk": {
+          "name": "combo_group_combo_id_combo_id_fk",
+          "tableFrom": "combo_group",
+          "tableTo": "combo",
+          "columnsFrom": [
+            "combo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.combo": {
+      "name": "combo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "combo_product_id_product_id_fk": {
+          "name": "combo_product_id_product_id_fk",
+          "tableFrom": "combo",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "combo_product_id_unique": {
+          "name": "combo_product_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nit": {
+          "name": "nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_code_org_idx": {
+          "name": "company_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_organization_id_organization_id_fk": {
+          "name": "company_organization_id_organization_id_fk",
+          "tableFrom": "company",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_rate": {
+      "name": "exchange_rate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_currency": {
+          "name": "from_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_currency": {
+          "name": "to_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rate_org_currencies_active_idx": {
+          "name": "exchange_rate_org_currencies_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_rate_organization_id_organization_id_fk": {
+          "name": "exchange_rate_organization_id_organization_id_fk",
+          "tableFrom": "exchange_rate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exchange_rate_created_by_user_id_fk": {
+          "name": "exchange_rate_created_by_user_id_fk",
+          "tableFrom": "exchange_rate",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "product_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STOCK'"
+        },
+        "track_inventory": {
+          "name": "track_inventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unit_of_measure_id": {
+          "name": "unit_of_measure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_sku_org_idx": {
+          "name": "product_sku_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_org_type_idx": {
+          "name": "product_org_type_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_organization_id_organization_id_fk": {
+          "name": "product_organization_id_organization_id_fk",
+          "tableFrom": "product",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "product_category_id_product_category_id_fk": {
+          "name": "product_category_id_product_category_id_fk",
+          "tableFrom": "product",
+          "tableTo": "product_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_category": {
+      "name": "product_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "product_category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_category_org_name_idx": {
+          "name": "product_category_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_category_organization_id_organization_id_fk": {
+          "name": "product_category_organization_id_organization_id_fk",
+          "tableFrom": "product_category",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sat_file": {
+      "name": "sat_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_type": {
+          "name": "invoice_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_type": {
+          "name": "dte_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dte_number": {
+          "name": "dte_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitter_nit": {
+          "name": "emitter_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emitter_name": {
+          "name": "emitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_nit": {
+          "name": "receptor_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_name": {
+          "name": "receptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportation": {
+          "name": "exportation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "certificator_nit": {
+          "name": "certificator_nit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificator_name": {
+          "name": "certificator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "money": {
+          "name": "money",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva": {
+          "name": "iva",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_voided": {
+          "name": "is_voided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "voided_date": {
+          "name": "voided_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "petroleum": {
+          "name": "petroleum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "hotel": {
+          "name": "hotel",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tickets": {
+          "name": "tickets",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "press_stamp": {
+          "name": "press_stamp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "firefighters": {
+          "name": "firefighters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "municipal_tax": {
+          "name": "municipal_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "alcoholic_tax": {
+          "name": "alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tobacco_tax": {
+          "name": "tobacco_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cement_tax": {
+          "name": "cement_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "no_alcoholic_tax": {
+          "name": "no_alcoholic_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "port_tariff_tax": {
+          "name": "port_tariff_tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sat_file_unique_dte_idx": {
+          "name": "sat_file_unique_dte_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "authorization_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serie",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dte_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sat_file_organization_id_organization_id_fk": {
+          "name": "sat_file_organization_id_organization_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_company_id_company_id_fk": {
+          "name": "sat_file_company_id_company_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_business_partner_id_business_partner_id_fk": {
+          "name": "sat_file_business_partner_id_business_partner_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sat_file_accounting_account_id_accounting_account_id_fk": {
+          "name": "sat_file_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "sat_file",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line": {
+      "name": "invoice_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "invoice_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'goods'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_invoice_id_invoice_id_fk": {
+          "name": "invoice_line_invoice_id_invoice_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_product_id_product_id_fk": {
+          "name": "invoice_line_product_id_product_id_fk",
+          "tableFrom": "invoice_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sat_file_id": {
+          "name": "sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serie": {
+          "name": "serie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "source": {
+          "name": "source",
+          "type": "invoice_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'FCE'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'L'"
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_organization_id_organization_id_fk": {
+          "name": "invoice_organization_id_organization_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_company_id_company_id_fk": {
+          "name": "invoice_company_id_company_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_business_partner_id_business_partner_id_fk": {
+          "name": "invoice_business_partner_id_business_partner_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_accounting_account_id_accounting_account_id_fk": {
+          "name": "invoice_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_sat_file_id_sat_file_id_fk": {
+          "name": "invoice_sat_file_id_sat_file_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_sucursal_id_sucursal_id_fk": {
+          "name": "invoice_sucursal_id_sucursal_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry_line": {
+      "name": "journal_entry_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_entry_id": {
+          "name": "journal_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accounting_account_id": {
+          "name": "accounting_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_amount": {
+          "name": "debit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "invoice_line_id": {
+          "name": "invoice_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_line_journal_entry_id_journal_entry_id_fk": {
+          "name": "journal_entry_line_journal_entry_id_journal_entry_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "journal_entry",
+          "columnsFrom": [
+            "journal_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_accounting_account_id_accounting_account_id_fk": {
+          "name": "journal_entry_line_accounting_account_id_accounting_account_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounting_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_line_invoice_line_id_invoice_line_id_fk": {
+          "name": "journal_entry_line_invoice_line_id_invoice_line_id_fk",
+          "tableFrom": "journal_entry_line",
+          "tableTo": "invoice_line",
+          "columnsFrom": [
+            "invoice_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry": {
+      "name": "journal_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_number": {
+          "name": "entry_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "journal_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_invoice_id": {
+          "name": "source_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sat_file_id": {
+          "name": "source_sat_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_pos_session_id": {
+          "name": "source_pos_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_debit": {
+          "name": "total_debit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_credit": {
+          "name": "total_credit",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "journal_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entry_organization_id_organization_id_fk": {
+          "name": "journal_entry_organization_id_organization_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_company_id_company_id_fk": {
+          "name": "journal_entry_company_id_company_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_invoice_id_invoice_id_fk": {
+          "name": "journal_entry_source_invoice_id_invoice_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "source_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_source_sat_file_id_sat_file_id_fk": {
+          "name": "journal_entry_source_sat_file_id_sat_file_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "sat_file",
+          "columnsFrom": [
+            "source_sat_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "journal_entry_posted_by_user_id_fk": {
+          "name": "journal_entry_posted_by_user_id_fk",
+          "tableFrom": "journal_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "posted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_accounting_config": {
+      "name": "organization_accounting_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_credito_fiscal_account_id": {
+          "name": "iva_credito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iva_debito_fiscal_account_id": {
+          "name": "iva_debito_fiscal_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_receivable_account_id": {
+          "name": "accounts_receivable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_payable_account_id": {
+          "name": "accounts_payable_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sales_account_id": {
+          "name": "default_sales_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_purchase_account_id": {
+          "name": "default_purchase_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journal_entry_prefix": {
+          "name": "journal_entry_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JE'"
+        },
+        "next_journal_entry_number": {
+          "name": "next_journal_entry_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "manual_invoice_prefix": {
+          "name": "manual_invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "next_manual_invoice_number": {
+          "name": "next_manual_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "order_prefix": {
+          "name": "order_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OR'"
+        },
+        "next_order_number": {
+          "name": "next_order_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_prefix": {
+          "name": "pos_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POS'"
+        },
+        "next_pos_sale_number": {
+          "name": "next_pos_sale_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "pos_cash_account_id": {
+          "name": "pos_cash_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_card_account_id": {
+          "name": "pos_card_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos_check_account_id": {
+          "name": "pos_check_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_accounting_config_organization_id_organization_id_fk": {
+          "name": "organization_accounting_config_organization_id_organization_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_credito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_credito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_iva_debito_fiscal_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "iva_debito_fiscal_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_receivable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_receivable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_accounts_payable_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "accounts_payable_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_sales_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_sales_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_sales_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_default_purchase_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "default_purchase_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_cash_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_cash_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_card_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_card_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_card_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_accounting_config_pos_check_account_id_accounting_account_id_fk": {
+          "name": "organization_accounting_config_pos_check_account_id_accounting_account_id_fk",
+          "tableFrom": "organization_accounting_config",
+          "tableTo": "accounting_account",
+          "columnsFrom": [
+            "pos_check_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_accounting_config_organization_id_unique": {
+          "name": "organization_accounting_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service": {
+      "name": "service",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "service_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "service_organization_id_organization_id_fk": {
+          "name": "service_organization_id_organization_id_fk",
+          "tableFrom": "service",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_movement": {
+      "name": "stock_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stock_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_date": {
+          "name": "movement_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stock_movement_organization_id_organization_id_fk": {
+          "name": "stock_movement_organization_id_organization_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_product_id_product_id_fk": {
+          "name": "stock_movement_product_id_product_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movement_created_by_id_user_id_fk": {
+          "name": "stock_movement_created_by_id_user_id_fk",
+          "tableFrom": "stock_movement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_detail": {
+      "name": "order_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "order_detail_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'product'"
+        },
+        "parent_line_id": {
+          "name": "parent_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "combo_template_id": {
+          "name": "combo_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_detail_order_id_order_id_fk": {
+          "name": "order_detail_order_id_order_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_detail_product_id_product_id_fk": {
+          "name": "order_detail_product_id_product_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_detail_combo_template_id_product_id_fk": {
+          "name": "order_detail_combo_template_id_product_id_fk",
+          "tableFrom": "order_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "combo_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_organization_id_organization_id_fk": {
+          "name": "order_organization_id_organization_id_fk",
+          "tableFrom": "order",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_company_id_company_id_fk": {
+          "name": "order_company_id_company_id_fk",
+          "tableFrom": "order",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_business_partner_id_business_partner_id_fk": {
+          "name": "order_business_partner_id_business_partner_id_fk",
+          "tableFrom": "order",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_recipient": {
+      "name": "order_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_detail_id": {
+          "name": "order_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_recipient_order_detail_id_order_detail_id_fk": {
+          "name": "order_recipient_order_detail_id_order_detail_id_fk",
+          "tableFrom": "order_recipient",
+          "tableTo": "order_detail",
+          "columnsFrom": [
+            "order_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_detail": {
+      "name": "quotation_detail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_id": {
+          "name": "quotation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "order_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_attributes_json": {
+          "name": "custom_attributes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_detail_quotation_id_quotation_id_fk": {
+          "name": "quotation_detail_quotation_id_quotation_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "quotation",
+          "columnsFrom": [
+            "quotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_detail_product_id_product_id_fk": {
+          "name": "quotation_detail_product_id_product_id_fk",
+          "tableFrom": "quotation_detail",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation": {
+      "name": "quotation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quotation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "quotation_date": {
+          "name": "quotation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotation_number": {
+          "name": "quotation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency_code": {
+          "name": "currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GT'"
+        },
+        "converted_order_id": {
+          "name": "converted_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_organization_id_organization_id_fk": {
+          "name": "quotation_organization_id_organization_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_company_id_company_id_fk": {
+          "name": "quotation_company_id_company_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_business_partner_id_business_partner_id_fk": {
+          "name": "quotation_business_partner_id_business_partner_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotation_converted_order_id_order_id_fk": {
+          "name": "quotation_converted_order_id_order_id_fk",
+          "tableFrom": "quotation",
+          "tableTo": "order",
+          "columnsFrom": [
+            "converted_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotation_recipient": {
+      "name": "quotation_recipient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quotation_detail_id": {
+          "name": "quotation_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotation_recipient_quotation_detail_id_quotation_detail_id_fk": {
+          "name": "quotation_recipient_quotation_detail_id_quotation_detail_id_fk",
+          "tableFrom": "quotation_recipient",
+          "tableTo": "quotation_detail",
+          "columnsFrom": [
+            "quotation_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cash_movement": {
+      "name": "pos_cash_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pos_cash_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_cash_movement_session_id_pos_session_id_fk": {
+          "name": "pos_cash_movement_session_id_pos_session_id_fk",
+          "tableFrom": "pos_cash_movement",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_cashier": {
+      "name": "pos_cashier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_attempts": {
+          "name": "pin_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pin_locked_at": {
+          "name": "pin_locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cashier_pin_org_idx": {
+          "name": "cashier_pin_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_cashier_organization_id_organization_id_fk": {
+          "name": "pos_cashier_organization_id_organization_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_cashier_user_id_user_id_fk": {
+          "name": "pos_cashier_user_id_user_id_fk",
+          "tableFrom": "pos_cashier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_payment": {
+      "name": "pos_payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "pos_payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_amount": {
+          "name": "received_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_payment_sale_id_pos_sale_id_fk": {
+          "name": "pos_payment_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_payment",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale_line": {
+      "name": "pos_sale_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "pos_sale_line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "parent_line_id": {
+          "name": "parent_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "combo_template_id": {
+          "name": "combo_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_percent": {
+          "name": "discount_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_type": {
+          "name": "iva_type",
+          "type": "iva_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'taxed'"
+        },
+        "iva_rate": {
+          "name": "iva_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12.00'"
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modifications_json": {
+          "name": "modifications_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_sale_line_sale_id_pos_sale_id_fk": {
+          "name": "pos_sale_line_sale_id_pos_sale_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pos_sale_line_combo_template_id_product_id_fk": {
+          "name": "pos_sale_line_combo_template_id_product_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "combo_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_line_product_id_product_id_fk": {
+          "name": "pos_sale_line_product_id_product_id_fk",
+          "tableFrom": "pos_sale_line",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_sale": {
+      "name": "pos_sale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_partner_id": {
+          "name": "business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_id": {
+          "name": "table_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_type": {
+          "name": "order_type",
+          "type": "pos_order_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'takeout'"
+        },
+        "cover_count": {
+          "name": "cover_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_number": {
+          "name": "sale_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_sale_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iva_amount": {
+          "name": "iva_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GTQ'"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_sale_idempotency_key_idx": {
+          "name": "pos_sale_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_terminal_created_idx": {
+          "name": "pos_sale_terminal_created_idx",
+          "columns": [
+            {
+              "expression": "terminal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_status_idx": {
+          "name": "pos_sale_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_sale_org_created_idx": {
+          "name": "pos_sale_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_sale_organization_id_organization_id_fk": {
+          "name": "pos_sale_organization_id_organization_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_sucursal_id_sucursal_id_fk": {
+          "name": "pos_sale_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_sale_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_sale_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_business_partner_id_business_partner_id_fk": {
+          "name": "pos_sale_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_table_id_pos_table_id_fk": {
+          "name": "pos_sale_table_id_pos_table_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "pos_table",
+          "columnsFrom": [
+            "table_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_company_id_company_id_fk": {
+          "name": "pos_sale_company_id_company_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_sale_invoice_id_invoice_id_fk": {
+          "name": "pos_sale_invoice_id_invoice_id_fk",
+          "tableFrom": "pos_sale",
+          "tableTo": "invoice",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_session": {
+      "name": "pos_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_id": {
+          "name": "cashier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_cash_amount": {
+          "name": "opening_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closing_cash_amount": {
+          "name": "closing_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash_amount": {
+          "name": "expected_cash_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_session_organization_id_organization_id_fk": {
+          "name": "pos_session_organization_id_organization_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_sucursal_id_sucursal_id_fk": {
+          "name": "pos_session_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_terminal_id_pos_terminal_id_fk": {
+          "name": "pos_session_terminal_id_pos_terminal_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_terminal",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_session_cashier_id_pos_cashier_id_fk": {
+          "name": "pos_session_cashier_id_pos_cashier_id_fk",
+          "tableFrom": "pos_session",
+          "tableTo": "pos_cashier",
+          "columnsFrom": [
+            "cashier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_table": {
+      "name": "pos_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pos_table_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_table_org_idx": {
+          "name": "pos_table_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pos_table_sucursal_idx": {
+          "name": "pos_table_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_table_organization_id_organization_id_fk": {
+          "name": "pos_table_organization_id_organization_id_fk",
+          "tableFrom": "pos_table",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_table_sucursal_id_sucursal_id_fk": {
+          "name": "pos_table_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_table",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_terminal": {
+      "name": "pos_terminal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "invoice_prefix": {
+          "name": "invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'T'"
+        },
+        "next_invoice_number": {
+          "name": "next_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "auto_generate_invoice": {
+          "name": "auto_generate_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_print_receipt": {
+          "name": "auto_print_receipt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "printer_name": {
+          "name": "printer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "print_method": {
+          "name": "print_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qz-tray'"
+        },
+        "kitchen_printer_name": {
+          "name": "kitchen_printer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kitchen_printer_host": {
+          "name": "kitchen_printer_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kitchen_printer_port": {
+          "name": "kitchen_printer_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kitchen_print_method": {
+          "name": "kitchen_print_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_business_partner_id": {
+          "name": "default_business_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pos_terminal_org_active_idx": {
+          "name": "pos_terminal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pos_terminal_organization_id_organization_id_fk": {
+          "name": "pos_terminal_organization_id_organization_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_sucursal_id_sucursal_id_fk": {
+          "name": "pos_terminal_sucursal_id_sucursal_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_default_business_partner_id_business_partner_id_fk": {
+          "name": "pos_terminal_default_business_partner_id_business_partner_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "business_partner",
+          "columnsFrom": [
+            "default_business_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_terminal_company_id_company_id_fk": {
+          "name": "pos_terminal_company_id_company_id_fk",
+          "tableFrom": "pos_terminal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pos_z_report": {
+      "name": "pos_z_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_name": {
+          "name": "terminal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cashier_name": {
+          "name": "cashier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opening_cash": {
+          "name": "opening_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_cash": {
+          "name": "closing_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_cash": {
+          "name": "expected_cash",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cash_difference": {
+          "name": "cash_difference",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sales": {
+          "name": "total_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cash_sales": {
+          "name": "total_cash_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_card_sales": {
+          "name": "total_card_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_check_sales": {
+          "name": "total_check_sales",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_refunds": {
+          "name": "total_refunds",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_withdrawals": {
+          "name": "total_withdrawals",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deposits": {
+          "name": "total_deposits",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tax": {
+          "name": "total_tax",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_order_time": {
+          "name": "first_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_time": {
+          "name": "last_order_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pos_z_report_session_id_pos_session_id_fk": {
+          "name": "pos_z_report_session_id_pos_session_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "pos_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pos_z_report_organization_id_organization_id_fk": {
+          "name": "pos_z_report_organization_id_organization_id_fk",
+          "tableFrom": "pos_z_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pos_z_report_session_id_unique": {
+          "name": "pos_z_report_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_movement": {
+      "name": "inventory_movement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "inventory_movement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_of_measure_id": {
+          "name": "unit_of_measure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inventory_movement_org_idx": {
+          "name": "inventory_movement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_product_idx": {
+          "name": "inventory_movement_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inventory_movement_sucursal_idx": {
+          "name": "inventory_movement_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_movement_organization_id_organization_id_fk": {
+          "name": "inventory_movement_organization_id_organization_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_sucursal_id_sucursal_id_fk": {
+          "name": "inventory_movement_sucursal_id_sucursal_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_movement_product_id_product_id_fk": {
+          "name": "inventory_movement_product_id_product_id_fk",
+          "tableFrom": "inventory_movement",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal_inventory": {
+      "name": "sucursal_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock": {
+          "name": "stock",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "min_stock": {
+          "name": "min_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_inventory_sucursal_product_idx": {
+          "name": "sucursal_inventory_sucursal_product_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_inventory_sucursal_idx": {
+          "name": "sucursal_inventory_sucursal_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_inventory_sucursal_id_sucursal_id_fk": {
+          "name": "sucursal_inventory_sucursal_id_sucursal_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sucursal_inventory_product_id_product_id_fk": {
+          "name": "sucursal_inventory_product_id_product_id_fk",
+          "tableFrom": "sucursal_inventory",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sucursal": {
+      "name": "sucursal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "invoice_prefix": {
+          "name": "invoice_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "next_invoice_number": {
+          "name": "next_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sucursal_code_org_idx": {
+          "name": "sucursal_code_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sucursal_org_active_idx": {
+          "name": "sucursal_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sucursal_organization_id_organization_id_fk": {
+          "name": "sucursal_organization_id_organization_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sucursal_company_id_company_id_fk": {
+          "name": "sucursal_company_id_company_id_fk",
+          "tableFrom": "sucursal",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_module_access": {
+      "name": "member_module_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_module_access_member_id_member_id_fk": {
+          "name": "member_module_access_member_id_member_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_module_access_organization_id_organization_id_fk": {
+          "name": "member_module_access_organization_id_organization_id_fk",
+          "tableFrom": "member_module_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_module_unique": {
+          "name": "member_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_module": {
+      "name": "organization_module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_module_organization_id_organization_id_fk": {
+          "name": "organization_module_organization_id_organization_id_fk",
+          "tableFrom": "organization_module",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_module_unique": {
+          "name": "org_module_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "module_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unit_of_measure": {
+      "name": "unit_of_measure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "uom_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'count'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "unit_of_measure_organization_id_organization_id_fk": {
+          "name": "unit_of_measure_organization_id_organization_id_fk",
+          "tableFrom": "unit_of_measure",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_item": {
+      "name": "recipe_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_product_id": {
+          "name": "ingredient_product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure_id": {
+          "name": "unit_of_measure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_item_recipe_id_recipe_id_fk": {
+          "name": "recipe_item_recipe_id_recipe_id_fk",
+          "tableFrom": "recipe_item",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_item_ingredient_product_id_product_id_fk": {
+          "name": "recipe_item_ingredient_product_id_product_id_fk",
+          "tableFrom": "recipe_item",
+          "tableTo": "product",
+          "columnsFrom": [
+            "ingredient_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_item_unit_of_measure_id_unit_of_measure_id_fk": {
+          "name": "recipe_item_unit_of_measure_id_unit_of_measure_id_fk",
+          "tableFrom": "recipe_item",
+          "tableTo": "unit_of_measure",
+          "columnsFrom": [
+            "unit_of_measure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_product_id_product_id_fk": {
+          "name": "recipe_product_id_product_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_product_id_unique": {
+          "name": "recipe_product_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "product_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kitchen_station": {
+      "name": "kitchen_station",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kitchen_station_organization_id_organization_id_fk": {
+          "name": "kitchen_station_organization_id_organization_id_fk",
+          "tableFrom": "kitchen_station",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "kitchen_station_sucursal_id_sucursal_id_fk": {
+          "name": "kitchen_station_sucursal_id_sucursal_id_fk",
+          "tableFrom": "kitchen_station",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kitchen_ticket_item": {
+      "name": "kitchen_ticket_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modifications_json": {
+          "name": "modifications_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "kitchen_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kitchen_ticket_item_ticket_id_kitchen_ticket_id_fk": {
+          "name": "kitchen_ticket_item_ticket_id_kitchen_ticket_id_fk",
+          "tableFrom": "kitchen_ticket_item",
+          "tableTo": "kitchen_ticket",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kitchen_ticket_item_product_id_product_id_fk": {
+          "name": "kitchen_ticket_item_product_id_product_id_fk",
+          "tableFrom": "kitchen_ticket_item",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "kitchen_ticket_item_station_id_kitchen_station_id_fk": {
+          "name": "kitchen_ticket_item_station_id_kitchen_station_id_fk",
+          "tableFrom": "kitchen_ticket_item",
+          "tableTo": "kitchen_station",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kitchen_ticket": {
+      "name": "kitchen_ticket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sucursal_id": {
+          "name": "sucursal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "kitchen_ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kitchen_ticket_sucursal_status_idx": {
+          "name": "kitchen_ticket_sucursal_status_idx",
+          "columns": [
+            {
+              "expression": "sucursal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kitchen_ticket_organization_id_organization_id_fk": {
+          "name": "kitchen_ticket_organization_id_organization_id_fk",
+          "tableFrom": "kitchen_ticket",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "kitchen_ticket_sucursal_id_sucursal_id_fk": {
+          "name": "kitchen_ticket_sucursal_id_sucursal_id_fk",
+          "tableFrom": "kitchen_ticket",
+          "tableTo": "sucursal",
+          "columnsFrom": [
+            "sucursal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "kitchen_ticket_sale_id_pos_sale_id_fk": {
+          "name": "kitchen_ticket_sale_id_pos_sale_id_fk",
+          "tableFrom": "kitchen_ticket",
+          "tableTo": "pos_sale",
+          "columnsFrom": [
+            "sale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "cancelled",
+        "completed"
+      ]
+    },
+    "public.inventory_movement_type": {
+      "name": "inventory_movement_type",
+      "schema": "public",
+      "values": [
+        "in",
+        "out",
+        "transfer_to_sucursal",
+        "transfer_from_sucursal",
+        "adjustment"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.invoice_type": {
+      "name": "invoice_type",
+      "schema": "public",
+      "values": [
+        "purchase",
+        "sale"
+      ]
+    },
+    "public.iva_type": {
+      "name": "iva_type",
+      "schema": "public",
+      "values": [
+        "taxed",
+        "exempt",
+        "non_subject"
+      ]
+    },
+    "public.journal_entry_source": {
+      "name": "journal_entry_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "invoice",
+        "adjustment",
+        "pos"
+      ]
+    },
+    "public.journal_entry_status": {
+      "name": "journal_entry_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided"
+      ]
+    },
+    "public.kitchen_item_status": {
+      "name": "kitchen_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready"
+      ]
+    },
+    "public.kitchen_ticket_status": {
+      "name": "kitchen_ticket_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "served"
+      ]
+    },
+    "public.order_detail_line_type": {
+      "name": "order_detail_line_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "combo",
+        "combo_item"
+      ]
+    },
+    "public.order_source_type": {
+      "name": "order_source_type",
+      "schema": "public",
+      "values": [
+        "INVENTORY",
+        "ON_DEMAND"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "CONFIRMED",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.pos_cash_movement_type": {
+      "name": "pos_cash_movement_type",
+      "schema": "public",
+      "values": [
+        "sale",
+        "refund",
+        "withdrawal",
+        "deposit"
+      ]
+    },
+    "public.pos_payment_method": {
+      "name": "pos_payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "card",
+        "check",
+        "cash_usd"
+      ]
+    },
+    "public.pos_sale_line_type": {
+      "name": "pos_sale_line_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "combo",
+        "combo_item"
+      ]
+    },
+    "public.pos_sale_status": {
+      "name": "pos_sale_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "completed",
+        "voided",
+        "refunded"
+      ]
+    },
+    "public.pos_session_status": {
+      "name": "pos_session_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.product_category_color": {
+      "name": "product_category_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow",
+        "pink",
+        "indigo",
+        "gray"
+      ]
+    },
+    "public.quotation_status": {
+      "name": "quotation_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "SENT",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.service_color": {
+      "name": "service_color",
+      "schema": "public",
+      "values": [
+        "blue",
+        "green",
+        "orange",
+        "teal",
+        "purple",
+        "red",
+        "yellow"
+      ]
+    },
+    "public.stock_movement_type": {
+      "name": "stock_movement_type",
+      "schema": "public",
+      "values": [
+        "entry",
+        "exit",
+        "adjustment"
+      ]
+    },
+    "public.uom_category": {
+      "name": "uom_category",
+      "schema": "public",
+      "values": [
+        "weight",
+        "volume",
+        "count",
+        "other"
+      ]
+    },
+    "public.product_type": {
+      "name": "product_type",
+      "schema": "public",
+      "values": [
+        "STOCK",
+        "MADE_TO_ORDER",
+        "SERVICE",
+        "ingredient",
+        "recipe",
+        "combo",
+        "sale_item"
+      ]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": [
+        "FCE",
+        "FAUCI",
+        "FPE",
+        "NC",
+        "DA",
+        "RCE",
+        "FCAM",
+        "NABN",
+        "OTRO"
+      ]
+    },
+    "public.invoice_line_type": {
+      "name": "invoice_line_type",
+      "schema": "public",
+      "values": [
+        "goods",
+        "services"
+      ]
+    },
+    "public.invoice_source": {
+      "name": "invoice_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sat"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "L",
+        "I",
+        "D"
+      ]
+    },
+    "public.pos_order_type": {
+      "name": "pos_order_type",
+      "schema": "public",
+      "values": [
+        "dine_in",
+        "takeout",
+        "delivery"
+      ]
+    },
+    "public.pos_table_status": {
+      "name": "pos_table_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "occupied",
+        "reserved"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1773259704134,
       "tag": "0029_slippery_vulcan",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1773292789688,
+      "tag": "0030_rainy_turbo",
+      "breakpoints": true
     }
   ]
 }

--- a/syncronizatoin_odoo.md
+++ b/syncronizatoin_odoo.md
@@ -1,0 +1,45 @@
+# Synchronization Odoo
+
+Note
+
+Access to data via the external API is only available on Custom Odoo pricing plans. Access to the external API is not available on One App Free or Standard plans. For more information visit the Odoo pricing page or reach out to your Customer Success Manager.
+
+## API documentation
+
+[Odoo API Documentation](https://www.odoo.com/documentation/18.0/developer/reference/external_api.html)
+
+## Synchronization by web hook
+
+### Entities
+
+Entities to be synchronized:
+
+Customer
+
+- res.partner
+
+Products
+
+- product.product
+
+Sales
+
+- sales.order
+- sales.order.line
+
+Invoices
+
+- account.move
+
+Payments
+
+- account.payment
+
+## Point of sale
+
+Create order at same time
+Dando clic al producto aumenta la cantidad
+La cantidad en numeros grandes en lugar de un boton para incrementar
+El teclado numerico aparece al seleccionar un producto de la lsita
+El producto muestra la canitdad y tallas
+Cuando le doy pago navega a la pagina de pago. Con opciones de efectivo tarjeta o cuenta del cliente


### PR DESCRIPTION
# Summary

- Export ModulesRepository class for testability
- Add autoGrantMemberAccess: when org activates a module, all members
  with 'none' access are upgraded to 'user' (admin/user preserved)
- Add revokeAllMembersAccess: when org deactivates a module, all
  members are set back to 'none'
- Wire auto-grant/revoke into /settings/modules action
- Add requireModule guard (app/server/auth/module.server.ts) that
  protects routes by module key, super admins bypass automatically
- Add tests for all new behavior (11 tests)
- requireModule now returns SessionData so it can replace requireAuth
  as a drop-in (avoids double auth call)
- Applied to pos-settings/terminals, cashiers, exchange-rates loaders
  and actions — unauthorized users are redirected to /home